### PR TITLE
Bugfix: remoteControl CL argument not working

### DIFF
--- a/src/PRo3D.Viewer/CommandLine/CommandLine.fs
+++ b/src/PRo3D.Viewer/CommandLine/CommandLine.fs
@@ -162,7 +162,7 @@ module CommandLine =
                             startEmpty            = startEmpty
                             useAsyncLoading       = useAsyncLoading
                             magnificationFilter   = false
-                            remoteApp             = false
+                            remoteApp             = remoteApp
                             serverMode            = server
                         }
                 args


### PR DESCRIPTION
Fixed tiny bug that meant remote control app could not be started.