### PR TITLE
Bugfix: Group names not displayed correctly #83

### DIFF
--- a/src/PRo3D.Core/Drawing/Drawing.UI.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.UI.fs
@@ -164,20 +164,7 @@ module UI =
                 
     let rec viewTree path (group : AdaptiveNode) (model : AdaptiveGroupsModel) (lookup : amap<Guid, AdaptiveAnnotation>) : DomNode<DrawingAction> =
                                                   
-        let activeIcon =
-            adaptive {
-                let! s = model.activeGroup    
-                let active = s.id
-                let! group  =  group.key
-
-                return if (active = group) then "circle icon" else "circle thin icon"
-            }
-                                      
-        let setActiveAction = 
-            GroupsAppAction.SetActiveGroup (group.key |> AVal.force, path, group.name |> AVal.force)
-            |> GroupsMessage
-
-        let setActiveAttributes = GroupsApp.clickIconAttributes activeIcon setActiveAction
+        let setActiveAttributes = GroupsApp.setActiveGroupAttributeMap path model group GroupsMessage
                        
         let color = sprintf "color: %s" (Html.ofC4b C4b.White)
         let desc =

--- a/src/PRo3D.Core/GroupsApp.fs
+++ b/src/PRo3D.Core/GroupsApp.fs
@@ -530,6 +530,26 @@ module GroupsApp =
             yield onClick (fun _ -> action)
         } |> AttributeMap.ofAMap
 
+    let activeIcon (model : AdaptiveGroupsModel)
+                   (group : AdaptiveNode) =
+        adaptive { 
+            let! activeGroup = model.activeGroup
+            let! group  =  group.key
+            return if (activeGroup.id = group) then "circle icon" else "circle thin icon"
+        }
+
+    let setActiveGroupAttributeMap (path : list<Index>)
+                                   (model : AdaptiveGroupsModel)
+                                   (group : AdaptiveNode) 
+                                   (msg : GroupsAppAction -> 'a) =
+        amap {
+            let! name = group.name
+            let setActive = GroupsAppAction.SetActiveGroup (group.key |> AVal.force, path, name)
+            let! icon = activeIcon model group
+            yield clazz icon
+            yield onClick (fun _ -> (msg setActive))
+        } |> AttributeMap.ofAMap
+
     let viewSelectionButtons =
         // Html.table [
         div[][

--- a/src/PRo3D.Core/Surface/SurfaceApp.fs
+++ b/src/PRo3D.Core/Surface/SurfaceApp.fs
@@ -685,16 +685,7 @@ module SurfaceApp =
             let! s = model.activeGroup
             let color = sprintf "color: %s" (Html.ofC4b C4b.White)                
             let children = AList.collecti (fun i v -> viewTree (i::path) v model) group.subNodes    
-
-            let activeIcon =
-                adaptive {                    
-                    let! group  =  group.key
-                    return if (s.id = group) then "circle icon" else "circle thin icon"
-                }
-
-            let setActive = GroupsAppAction.SetActiveGroup (group.key |> AVal.force, path, group.name |> AVal.force)
-            let activeAttributes = 
-                GroupsApp.clickIconAttributes activeIcon (GroupsMessage setActive)
+            let activeAttributes = GroupsApp.setActiveGroupAttributeMap path model group GroupsMessage
                                    
             let toggleIcon = 
                 AVal.constant "unhide icon" //group.visible |> AVal.map(fun toggle -> if toggle then "unhide icon" else "hide icon")                

--- a/src/PRo3D.Viewer/Bookmarks.fs
+++ b/src/PRo3D.Viewer/Bookmarks.fs
@@ -190,17 +190,7 @@ module Bookmarks =
             let! active = model.activeGroup
             let color = sprintf "color: %s" (Html.ofC4b C4b.White)                
             
-
-            let icon =
-                adaptive {                    
-                    let! group  =  group.key
-                    return if (active.id = group) then "circle icon" else "circle thin icon"
-                }
-                      
-            let map = 
-                GroupsApp.clickIconAttributes 
-                    icon 
-                    (BookmarkAction.GroupsMessage(GroupsAppAction.SetActiveGroup (group.key |> AVal.force, path, group.name |> AVal.force)))
+            let map = GroupsApp.setActiveGroupAttributeMap path model group GroupsMessage
                
             let desc =
                 div [style color] [       


### PR DESCRIPTION
Group names (Annotations, Bookmarks, and Surfaces) in text field for editing name were not displayed correctly when changed. Fixed.