### PR TITLE
Extend geojson property export

### DIFF
--- a/src/PRo3D.Base/Annotation/Exporters/GeoJSON.Export.fs
+++ b/src/PRo3D.Base/Annotation/Exporters/GeoJSON.Export.fs
@@ -126,6 +126,8 @@ module GeoJSONExport =
                                 ("id", annotation.key.ToString() |> Json.String)
                                 ("color", annotation.color.c.ToString() |> Json.String)
                                 ("geometry", annotation.geometry.ToString() |> Json.String)
+                                ("text", annotation.text |> Json.String)
+                                ("surfaceName", annotation.surfaceName |> Json.String)
                                 // extend as desired. https://github.com/pro3d-space/PRo3D/issues/185
                             ]
                     }


### PR DESCRIPTION
adds text and surface name to export to make it easier to distinguish annotations that are exported