### PR TITLE
cross platform openPath usage

### DIFF
--- a/src/PRo3D.Core/SceneObjectsApp.fs
+++ b/src/PRo3D.Core/SceneObjectsApp.fs
@@ -6,6 +6,7 @@ open Aardvark.UI
 open Aardvark.VRVis
 open FSharp.Data.Adaptive
 open Adaptify.FSharp.Core
+open Aardvark.electron.shell
 open Aardvark.SceneGraph.IO
 open Aardvark.SceneGraph.SgPrimitives
 open Aardvark.Rendering
@@ -156,7 +157,7 @@ module SceneObjectsApp =
             let test = Path.GetDirectoryName so.importPath
             match File.Exists(so.importPath) with
             | true -> 
-                Process.Start("explorer.exe", test) |> ignore
+                shell.openPath(test) |> ignore
                 model
             | false -> model
         | SelectSO id ->

--- a/src/PRo3D.Core/Surface/SurfaceApp.fs
+++ b/src/PRo3D.Core/Surface/SurfaceApp.fs
@@ -6,6 +6,7 @@ open System.Diagnostics
 open FSharp.Data.Adaptive
 
 open Aardvark.Base
+open Aardvark.electron.shell
 open Aardvark.UI
 open Aardvark.UI.Primitives
 open Aardvark.Rendering
@@ -637,7 +638,7 @@ module SurfaceApp =
                     let path = Files.getSurfaceFolder sf scenePath
                     match path with
                     | Some p -> 
-                        Process.Start("explorer.exe", p) |> ignore
+                        shell.openPath(p)  |> ignore
                         model
                     | None -> model
                 | _ -> failwith "can only contain surfaces"
@@ -973,7 +974,7 @@ module SurfaceApp =
                     //        let path = Files.getSurfaceFolder sf scenePath
                     //        match path with
                     //        | Some p -> 
-                    //            Process.Start("explorer.exe", p) |> ignore
+                    //            shell.openPath(p)  |> ignore
                     //            model
                     //        | None -> model
                     //    | _ -> failwith "can only contain surfaces"

--- a/src/PRo3D.Minerva/Utilities.fs
+++ b/src/PRo3D.Minerva/Utilities.fs
@@ -5,6 +5,7 @@ open System.IO
 open System.Diagnostics
 
 open Aardvark.Base
+open Aardvark.electron.shell
 open Aardvark.Rendering
 open Aardvark.Rendering.Text 
 open FSharp.Data.Adaptive
@@ -49,7 +50,7 @@ module Files =
 
     let openExplorer filePath =
         let argument = sprintf "/select, \"%s\"" filePath
-        Process.Start("explorer.exe", argument) |> ignore
+        shell.openPath(argument) |> ignore
 
     let downloadAndOpenTif (featureId:string) (model:MinervaModel) =
         // https://minerva.eox.at/store/datafile/FRB_495137799RADLF0492626FHAZ00323M1/frb_495137799radlf0492626fhaz00323m1.tif

--- a/src/PRo3D.SimulatedViews/Screenshots/ScreenshotApp.fs
+++ b/src/PRo3D.SimulatedViews/Screenshots/ScreenshotApp.fs
@@ -1,6 +1,7 @@
 ﻿namespace PRo3D.SimulatedViews
 
 open Aardvark.Base
+open Aardvark.electron.shell
 open Aardvark.UI
 open PRo3D.Base
 open System.IO
@@ -70,7 +71,7 @@ module ScreenshotApp =
         | SetImageFormat format ->
             { m with imageFormat = format }
         | OpenFolder ->
-            System.Diagnostics.Process.Start("explorer.exe", outputPath) |> ignore
+            shell.openPath(outputPath) |> ignore
             m
 
     let view (m : AdaptiveScreenshotModel) = 

--- a/src/PRo3D.SimulatedViews/Viewplanner/ViewPlanApp.fs
+++ b/src/PRo3D.SimulatedViews/Viewplanner/ViewPlanApp.fs
@@ -8,6 +8,7 @@ open FSharp.Data.Adaptive
 open FSharp.Data.Adaptive.Operators
 
 open Aardvark.Base
+open Aardvark.electron.shell
 open Aardvark.Rendering
 open Aardvark.Application
 open Aardvark.Geometry
@@ -658,7 +659,7 @@ module ViewPlanApp =
             match scenepath with
             | Some sp -> 
                 let fpPath = FootPrint.getFootprintsPath sp
-                if (Directory.Exists fpPath) then Process.Start("explorer.exe", fpPath) |> ignore
+                if (Directory.Exists fpPath) then shell.openPath(fpPath) |> ignore
                 outerModel, model
             | None -> outerModel, model        
 

--- a/src/PRo3D.Snapshots/ViewPlan.fs
+++ b/src/PRo3D.Snapshots/ViewPlan.fs
@@ -2,6 +2,7 @@ namespace PRo3D
 
 open Aardvark.Base
 open Aardvark.Application
+open Aardvark.electron.shell
 open Aardvark.UI
 open Aardvark.VRVis
 open FSharp.Data.Adaptive
@@ -430,7 +431,7 @@ module ViewPlan =
                     | Some sp -> 
                         let fpPath = FootPrint.getFootprintsPath sp
                         if (Directory.Exists fpPath) then
-                                Process.Start("explorer.exe", fpPath) |> ignore
+                                shell.openPath(fpPath) |> ignore
                         outerModel, model
                     | None -> outerModel, model
             //| _ -> model

--- a/src/PRo3D.Viewer/RemoteControlApp.fs
+++ b/src/PRo3D.Viewer/RemoteControlApp.fs
@@ -4,6 +4,7 @@ open System
 open System.Diagnostics
 open FSharp.Data.Adaptive    
 open Aardvark.Base
+open Aardvark.electron.shell
 open Aardvark.UI
 open PRo3D.Base
 open PRo3D.Core
@@ -149,7 +150,7 @@ module RemoteControlApp =
                 System.IO.File.Delete "./remote.mdl"
                 m
             | OpenFolder path ->
-                Process.Start("explorer.exe", path) |> ignore
+                shell.openPath(path) |> ignore
                 m
             | RoverMessage a ->                
                 let m = { m with Rover = RoverApp.update m.Rover a }                                

--- a/src/PRo3D.Viewer/ViewPlan.fs
+++ b/src/PRo3D.Viewer/ViewPlan.fs
@@ -2,6 +2,7 @@ namespace PRo3D
 
 open Aardvark.Base
 open Aardvark.Application
+open Aardvark.electron.shell
 open Aardvark.UI
 open Aardvark.VRVis
 open FSharp.Data.Adaptive
@@ -430,7 +431,7 @@ module ViewPlan =
                     | Some sp -> 
                         let fpPath = FootPrint.getFootprintsPath sp
                         if (Directory.Exists fpPath) then
-                                Process.Start("explorer.exe", fpPath) |> ignore
+                                shell.openPath(fpPath) |> ignore
                         outerModel, model
                     | None -> outerModel, model
             //| _ -> model

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -11,6 +11,7 @@ open Adaptify.FSharp.Core
 
 open Aardvark.Base
 open Aardvark.Base.Geometry
+open Aardvark.electron.shell
 open FSharp.Data.Adaptive
 open FSharp.Data.Adaptive.Operators
 open Aardvark.Rendering
@@ -1303,7 +1304,7 @@ module ViewerApp =
             { m with viewerMode = vm }
         | OpenSceneFileLocation p,_,_ ->                
             let argument = sprintf "/select, \"%s\"" p
-            Process.Start("explorer.exe", argument) |> ignore
+            shell.openPath(argument) |> ignore
             m
         | NoAction s,_,_ -> 
             if s.IsEmptyOrNull() |> not then 

--- a/src/PRo3D.Viewplanner/ViewPlan.fs
+++ b/src/PRo3D.Viewplanner/ViewPlan.fs
@@ -2,6 +2,7 @@ namespace PRo3D
 
 open Aardvark.Base
 open Aardvark.Application
+open Aardvark.electron.shell
 open Aardvark.UI
 open Aardvark.VRVis
 open FSharp.Data.Adaptive
@@ -473,7 +474,7 @@ module ViewPlanApp =
         match scenepath with
         | Some sp -> 
           let fpPath = FootPrint.getFootprintsPath sp
-          if (Directory.Exists fpPath) then Process.Start("explorer.exe", fpPath) |> ignore
+          if (Directory.Exists fpPath) then shell.openPath(fpPath) |> ignore
           outerModel, model
         | None -> outerModel, model        
 


### PR DESCRIPTION
* attempts to replace all usages of explorer.exe for electron equivalent

fsharp's syntax is fairly weird to me, so no doubt I am doing something incorrectly here either with the promise<string> returned by electron.