### PR TITLE
Bugfix frustum not set in batch rendering with CameraAnimation

### DIFF
--- a/src/PRo3D.SimulatedViews/Snapshots/Snapshot-Model.fs
+++ b/src/PRo3D.SimulatedViews/Snapshots/Snapshot-Model.fs
@@ -307,6 +307,28 @@ type CameraSnapshotAnimation = {
 with 
   static member defaultNearplane = 0.1
   static member defaultFarplane  = 100000.0
+  static member defaultFoV = 30.0
+  member  snapshotAnimation.Frustum = 
+      let resolution = V3i (snapshotAnimation.resolution.X, snapshotAnimation.resolution.Y, 1)
+
+      let foV = 
+          match snapshotAnimation.fieldOfView with
+          | Some fov -> fov
+          | None -> CameraSnapshotAnimation.defaultFoV
+
+      let near =
+          match snapshotAnimation.nearplane with
+          | Some near -> near
+          | None -> CameraSnapshotAnimation.defaultNearplane
+
+      let far =
+          match snapshotAnimation.farplane with
+          | Some far -> far
+          | None -> CameraSnapshotAnimation.defaultFarplane
+      let frustum =
+          Frustum.perspective foV near far (float(resolution.X)/float(resolution.Y))
+      frustum
+
   static member TestData =
       {
           fieldOfView = Some 5.47

--- a/src/PRo3D.Snapshots/Viewer/SnapshotGenerator.fs
+++ b/src/PRo3D.Snapshots/Viewer/SnapshotGenerator.fs
@@ -124,7 +124,11 @@ module SnapshotGenerator =
     let getAnimationActions (anim : SnapshotAnimation) =       
         match anim with
         | SnapshotAnimation.CameraAnimation a ->
-            Seq.singleton (ViewerAction.SetRenderViewportSize a.resolution |> ViewerMessage)
+            seq {
+                yield ViewerAction.SetRenderViewportSize a.resolution |> ViewerMessage
+                yield ViewerAction.SetFrustum a.Frustum |> ViewerMessage
+            }
+
         | SnapshotAnimation.BookmarkAnimation a ->
             [
              (ViewerAction.SetFrustum (SnapshotApp.calculateFrustum a)) |> ViewerMessage


### PR DESCRIPTION
fov, nearplane and farplane as set in json file will now be used for batch rendering with CameraAnimation