### PR TITLE
added global.json to prevent such problems in the future https://gith…

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.203",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
added global.json (currently .net 6) to have reproducible builds with new dotnet sdks....

Also a (late) response to that issue https://github.com/pro3d-space/PRo3D/issues/173