### PR TITLE
Fix for sporadic crashes on `NewScene`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 on:
-  push:
+  push: 
     paths:
       - PRODUCT_RELEASE_NOTES.md
       - aardium/package.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,6 @@
 name: Deploy
 on:
   push:
-    branches:
-      - autorelease
-      - develop
-      - bugs/fixMultiObjs
     paths:
       - PRODUCT_RELEASE_NOTES.md
       - aardium/package.json

--- a/PRODUCT_RELEASE_NOTES.md
+++ b/PRODUCT_RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 4.11.0-prerelease4
+- NewScene crash fixed: https://github.com/pro3d-space/PRo3D/issues/277
+
 ## 4.11.0-prerelease3
 - #274: objs with multiple geometries fixed
 

--- a/aardium/package.json
+++ b/aardium/package.json
@@ -1,7 +1,7 @@
 {
   "name": "PRo3D",
   "productName": "PRo3D.Viewer",
-  "version": "4.11.0",
+  "version": "4.11.0-prerelease4",
   "description": "PRo3D, short for Planetary Robotics 3D Viewer, is an interactive 3D visualization tool to allow planetary scientists to work with high-resolution 3D reconstructions of the Martian surface.",
   "license": "AGPL",
   "copyright": "VRVis Zentrum für Virtual Reality und Visualisierung Forschungs-GmbH",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.203",
+    "version": "6.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/PRo3D.Core/Surface.fs
+++ b/src/PRo3D.Core/Surface.fs
@@ -60,6 +60,15 @@ module SurfaceTransformations =
             
             return fullTrafo' s rSys
         }
+    
+    let fullTrafoForSurface (surf : AdaptiveSurface) (refsys : AdaptiveReferenceSystem) = 
+        adaptive {
+            let s = surf
+            let! s = s.Current
+            let! rSys = refsys.Current
+            
+            return fullTrafo' s rSys
+        }
 module DebugKdTreesX = 
    
     let getInvalidIndices3f (positions : V3f[]) =

--- a/src/PRo3D.Core/Surface/SurfaceUtils.fs
+++ b/src/PRo3D.Core/Surface/SurfaceUtils.fs
@@ -13,6 +13,8 @@ open PRo3D.Core.Surface
 open Adaptify.FSharp.Core
 
 module SurfaceUtils =
+
+    [<Obsolete("toModSurface might throw and is not safe to use. see https://github.com/pro3d-space/PRo3D/issues/277")>]
     let toModSurface (leaf : AdaptiveLeafCase) = 
          adaptive {
             let c = leaf
@@ -21,8 +23,18 @@ module SurfaceUtils =
                 | _ -> return c |> sprintf "wrong type %A; expected AdaptiveSurfaces" |> failwith
             }
          
-    let lookUp guid (surfaces:amap<Guid, AdaptiveLeafCase>) =
-        let entry = surfaces |> AMap.find guid
+    [<Obsolete("lookup might throw and is not safe to use. see https://github.com/pro3d-space/PRo3D/issues/277")>]
+    let lookUp (guid : Guid) (table:amap<Guid, AdaptiveLeafCase>) =
+        let entry = 
+            adaptive { 
+                match! table |> AMap.tryFind guid with
+                | None -> 
+                    // we can only throw here..... see https://github.com/pro3d-space/PRo3D/issues/277
+                    return failwithf "surface with guid %A not found" guid
+                | Some e -> 
+                    return e
+            }
+
         entry |> AVal.bind(fun x -> x |> toModSurface)
 
     let toAvalSurfaces (surfaces : amap<Guid, AdaptiveLeafCase>) =

--- a/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerGUI.fs
@@ -303,7 +303,7 @@ module Gui =
                         Dialogs.onChooseFiles (curry ViewerAction.ImportObject MeshLoaderType.Wavefront);
                         clientEvent "onclick" (jsImportOBJDialog)
                     ] [
-                        text "Import (*.obj) using the aardvark wavefront loader"
+                        text "Import (*.obj)"
                     ]
                     //div [ clazz "ui inverted item"; 
                     //    Dialogs.onChooseFiles (curry ViewerAction.ImportObject MeshLoaderType.GlTf);


### PR DESCRIPTION
As noted in this issue: https://github.com/pro3d-space/PRo3D/issues/277, we have tons of unsafe Map.find/AMap.find calls. This fix, fixes the most important occurance, which leads to sporadic hard-to-debug failures when loading opcs asynchronously.