### PR TITLE
Features/296 trafo

### DIFF
--- a/src/PRo3D.Base/FalseColors/FalseColors-Model.fs
+++ b/src/PRo3D.Base/FalseColors/FalseColors-Model.fs
@@ -149,7 +149,7 @@ module FalseColorsModel =
     let initMinDepth = {
         value   = 0.0
         min     = 0.0
-        max     = 100.0
+        max     = 10000.0
         step    = 1.0
         format  = "{0:0.0}"
     }

--- a/src/PRo3D.Core/ScaleBars-Model.fs
+++ b/src/PRo3D.Core/ScaleBars-Model.fs
@@ -331,6 +331,7 @@ module InitScaleBarsParams =
         scaling              = Transformations.Initial.scaling
         trafoChanged         = false
         usePivot             = false
+        pivotSize            = Transformations.Initial.initPivotSize 0.4
     }
 
     let thickness = {

--- a/src/PRo3D.Core/ScaleBarsApp.fs
+++ b/src/PRo3D.Core/ScaleBarsApp.fs
@@ -269,7 +269,8 @@ module ScaleBarsApp =
 
     let update 
         (model : ScaleBarsModel) 
-        (act   : ScaleBarsAction) = 
+        (act   : ScaleBarsAction) 
+        (refSys : ReferenceSystem) = 
 
         match act with
         | IsVisible id ->
@@ -308,7 +309,7 @@ module ScaleBarsApp =
                 let scB = model.scaleBars |> HashMap.tryFind id
                 match scB with
                 | Some sb ->
-                    let transformation' = (TransformationApp.update sb.transformation msg)
+                    let transformation' = (TransformationApp.update sb.transformation msg refSys)
                     let sb' = { sb with transformation = transformation' }
                     let scaleBars = model.scaleBars |> HashMap.alter sb.guid (function | Some _ -> Some sb' | None -> None )
                     { model with scaleBars = scaleBars} 

--- a/src/PRo3D.Core/SceneObjects-Model.fs
+++ b/src/PRo3D.Core/SceneObjects-Model.fs
@@ -216,6 +216,7 @@ module InitSceneObjectParams =
         scaling              = Transformations.Initial.scaling
         trafoChanged         = false
         usePivot             = false
+        pivotSize            = Transformations.Initial.initPivotSize 0.4
     }
 
     let initNoffset = {

--- a/src/PRo3D.Core/SceneObjectsApp.fs
+++ b/src/PRo3D.Core/SceneObjectsApp.fs
@@ -146,7 +146,8 @@ module SceneObjectsApp =
 
     let update 
         (model : SceneObjectsModel) 
-        (act : SceneObjectAction) = 
+        (act : SceneObjectAction) 
+        (refSys : ReferenceSystem) = 
 
         match act with
         | IsVisible id ->
@@ -179,7 +180,7 @@ module SceneObjectsApp =
                 let sobj = model.sceneObjects |> HashMap.tryFind id
                 match sobj with
                 | Some so ->
-                    let transformation' = (TransformationApp.update so.transformation msg)
+                    let transformation' = (TransformationApp.update so.transformation msg refSys)
                     let selSO = { so with transformation = transformation' }
                     let sceneObjs = model.sceneObjects |> HashMap.alter so.guid (function | Some _ -> Some selSO | None -> None )
                     { model with sceneObjects = sceneObjs} 

--- a/src/PRo3D.Core/Surface-Model.fs
+++ b/src/PRo3D.Core/Surface-Model.fs
@@ -613,6 +613,7 @@ module Init =
         scaling              = Transformations.Initial.scaling
         trafoChanged         = false
         usePivot             = false
+        pivotSize            = Transformations.Initial.initPivotSize 0.4
     }
     
 

--- a/src/PRo3D.Core/Surface.fs
+++ b/src/PRo3D.Core/Surface.fs
@@ -185,8 +185,7 @@ module SurfaceIntersection =
             |> HashMap.toList 
             |> List.choose (fun (id,leaf) -> 
                 match m.sgSurfaces |> HashMap.tryFind id with
-                | None -> None
-                | Some s -> 
+                 | Some s -> 
                     if filterSurface id leaf s then Some s
                     else None
             )

--- a/src/PRo3D.Core/Surface/SurfaceApp.fs
+++ b/src/PRo3D.Core/Surface/SurfaceApp.fs
@@ -1046,7 +1046,7 @@ module SurfaceApp =
                                 surface.transformation
                              else 
                                 { surface.transformation with pivot = Vector3d.updateV3d surface.transformation.pivot refSys.origin }
-                    let transformation' = (TransformationApp.update t msg) //surface.transformation msg)
+                    let transformation' = (TransformationApp.update t msg refSys) //surface.transformation msg)
                     let s' = { surface with transformation = transformation' }
                     //let homePosition = 
                     //  match surface.homePosition with

--- a/src/PRo3D.Core/Transformation-Model.fs
+++ b/src/PRo3D.Core/Transformation-Model.fs
@@ -40,6 +40,7 @@ type Transformations = {
     scaling               : NumericInput
     trafoChanged          : bool
     usePivot              : bool
+    pivotSize             : NumericInput
 } 
 
 
@@ -92,6 +93,15 @@ module Transformations =
             value = v    
         }
 
+        let initPivotSize size = 
+            {
+                value = size
+                min = 0.3
+                max = 15.0
+                step = 0.1
+                format = "{0:0.00}"
+            }
+
     let current = 6 //4 //21.12.2022 laura
     
     let read0 = 
@@ -121,6 +131,7 @@ module Transformations =
                 scaling              = Initial.scaling
                 trafoChanged         = false
                 usePivot             = false
+                pivotSize            = Initial.initPivotSize 4.0
             }
         }
 
@@ -151,6 +162,7 @@ module Transformations =
                 scaling              = Initial.scaling
                 trafoChanged         = false
                 usePivot             = false
+                pivotSize            = Initial.initPivotSize 4.0
             }
         }
 
@@ -169,7 +181,7 @@ module Transformations =
                 version              = current
                 useTranslationArrows = useTranslationArrows
                 translation          = translation
-                yaw                  = yaw                 
+                yaw                  = yaw            
                 pitch                = Initial.pitch
                 roll                 = Initial.roll
                 trafo                = trafo               
@@ -182,6 +194,7 @@ module Transformations =
                 scaling              = Initial.scaling
                 trafoChanged         = false
                 usePivot             = false
+                pivotSize            = Initial.initPivotSize 4.0
             }
         }
 
@@ -216,6 +229,7 @@ module Transformations =
                 scaling              = Initial.scaling
                 trafoChanged         = false
                 usePivot             = false
+                pivotSize            = Initial.initPivotSize 4.0
             }
         }
 
@@ -251,6 +265,7 @@ module Transformations =
                 scaling              = Initial.scaling //scaling
                 trafoChanged         = false
                 usePivot             = false
+                pivotSize            = Initial.initPivotSize 4.0
             }
         }
 
@@ -285,6 +300,7 @@ module Transformations =
                 scaling              = scaling
                 trafoChanged         = false
                 usePivot             = false
+                pivotSize            = Initial.initPivotSize 4.0
             }
         }
     
@@ -303,6 +319,7 @@ module Transformations =
             let! flipZ                = Json.read "flipZ"
             let! isSketchFab          = Json.read "isSketchFab"
             let! usePivot             = Json.read "usePivot"
+            let! pivotSize            = Json.tryRead "pivotSize"
             
             return {
                 version              = current
@@ -321,6 +338,7 @@ module Transformations =
                 scaling              = scaling
                 trafoChanged         = false
                 usePivot             = usePivot
+                pivotSize            = match pivotSize with |Some p -> Initial.initPivotSize p | None -> Initial.initPivotSize 4.0
             }
         }
 
@@ -359,6 +377,7 @@ type Transformations with
             do! Json.write "flipZ" x.flipZ
             do! Json.write "isSketchFab" x.isSketchFab
             do! Json.write "usePivot" x.usePivot
+            do! Json.write "pivotSize" x.pivotSize.value
         }
 
 

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -349,12 +349,12 @@ module ViewerApp =
             { m with heighValidation = heightVal }
         | Interactions.PlaceScaleBar, _ ->
             let msg = ScaleBarsAction.AddScaleBar(p, m.scaleBarsDrawing, m.navigation.camera.view)
-            let scm = ScaleBarsApp.update m.scene.scaleBars msg
+            let scm = ScaleBarsApp.update m.scene.scaleBars msg m.scene.referenceSystem
             { m with scene = { m.scene with scaleBars = scm } }
         | Interactions.PlaceSceneObject, ViewerMode.Standard -> 
             //let action = (SceneObjectAction.PlaceSceneObject(p))
             let action = (SceneObjectAction.TranslationMessage( TransformationApp.Action.SetPickedTranslation(p)))
-            let sobjs = SceneObjectsApp.update m.scene.sceneObjectsModel action
+            let sobjs = SceneObjectsApp.update m.scene.sceneObjectsModel action m.scene.referenceSystem
             { m with scene = { m.scene with sceneObjectsModel = sobjs } }
         | Interactions.PickPivotPoint, ViewerMode.Standard -> 
             match m.pivotType with
@@ -371,7 +371,7 @@ module ViewerApp =
             | PickPivot.SceneObjectPivot -> 
                 let action = (SceneObjectAction.TranslationMessage( TransformationApp.Action.SetPickedPivotPoint p )) 
                 let so' =
-                    SceneObjectsApp.update m.scene.sceneObjectsModel action 
+                    SceneObjectsApp.update m.scene.sceneObjectsModel action m.scene.referenceSystem
                 { m with scene = { m.scene with sceneObjectsModel = so' } }
             | _ -> m
         | _ -> m       
@@ -692,7 +692,7 @@ module ViewerApp =
             let cm = FalseColorLegendApp.update m.drawing.dnsColorLegend msg
             { m with drawing = { m.drawing with dnsColorLegend = cm } }
         | SceneObjectsMessage msg,_,_ -> 
-            let sobjs = SceneObjectsApp.update m.scene.sceneObjectsModel msg
+            let sobjs = SceneObjectsApp.update m.scene.sceneObjectsModel msg m.scene.referenceSystem
             let animation = 
                 match msg with
                 | SceneObjectAction.FlyToSO id -> 
@@ -915,6 +915,10 @@ module ViewerApp =
 
             if computeExactPick then    // CHECK-merge
 
+                //// hack
+                //let pp = m.navigation.exploreCenter
+                //let navigation' = 
+                //    Navigation.update m.scene.config m.scene.referenceSystem navConf true m.navigation (Navigation.Action.ArcBallAction(ArcBallController.Message.Pick pp))
                 let fray = p.globalRay.Ray
                 let r = fray.Ray
                 let rayHash = r.GetHashCode()
@@ -958,7 +962,7 @@ module ViewerApp =
 
                             Log.line "[PickSurface] surface hit at %A" hit
 
-                            let cameraLocation = m.navigation.camera.view.Location 
+                            let cameraLocation = m.navigation.camera.view.Location //navigation'.camera.view.Location 
                             let hitF = hitF cameraLocation
                    
                             lastHash <- rayHash
@@ -1440,7 +1444,7 @@ module ViewerApp =
                 | None -> m
             | _ ->
                 //let _scaleBarsModel = (Model.scene_ >-> Scene.scaleBars_ )
-                let scaleBars' = ScaleBarsApp.update m.scene.scaleBars msg
+                let scaleBars' = ScaleBarsApp.update m.scene.scaleBars msg m.scene.referenceSystem
                 let m' = m |> Optic.set _scaleBarsModel scaleBars'  
                 m'
         | GeologicSurfacesMessage msg,_,_-> 


### PR DESCRIPTION
trafo with pivot for each surface. keeps translation and resets scaling and rotation if pivot changes.
how to use:
- select a surface
- enable "use pivot" and "show pivot" in transformation menu for surface
- in picking actions set "PickPivot" for picking a pivot position with Strg + LMB
- adjust transformation via transformation gui 