### PR TITLE
Origin/features/scale bars orientations

### DIFF
--- a/src/PRo3D.Core/ScaleBars-Model.fs
+++ b/src/PRo3D.Core/ScaleBars-Model.fs
@@ -18,10 +18,10 @@ open Aether.Operators
 #nowarn "0686"
 
 type Orientation = 
-| Horizontal_cam    = 0 
-| Vertical_cam      = 1 
-| Sky_cam           = 2 
-| Horizontal_planet = 3 // 
+| Horizontal_cam    = 0 // right direction of camera view
+| Vertical_cam      = 1 // up direction of camera view
+| Sky_cam           = 2 // camera sky vector
+| Horizontal_planet = 3 // reference systen plane parallel to right camera view
 | Sky_planet        = 4 // up direction of reference system
 
 

--- a/src/PRo3D.Core/ScaleBars-Model.fs
+++ b/src/PRo3D.Core/ScaleBars-Model.fs
@@ -18,9 +18,12 @@ open Aether.Operators
 #nowarn "0686"
 
 type Orientation = 
-| Horizontal = 0 
-| Vertical   = 1 
-| Sky        = 2
+| Horizontal_cam    = 0 
+| Vertical_cam      = 1 
+| Sky_cam           = 2 
+| Horizontal_planet = 3 // 
+| Sky_planet        = 4 // up direction of reference system
+
 
 type Pivot = //alignment
 | Left   = 0
@@ -135,9 +138,9 @@ module ScaleBar =
         (view : CameraView) =  
 
         match orientation with
-        | Orientation.Horizontal -> view.Right
-        | Orientation.Vertical   -> view.Up
-        | Orientation.Sky        -> view.Sky
+        | Orientation.Horizontal_cam    -> view.Right
+        | Orientation.Vertical_cam      -> view.Up
+        | Orientation.Sky_cam           -> view.Sky
         |_                       -> view.Right
 
     let current = 0   
@@ -171,6 +174,8 @@ module ScaleBar =
 
             let orientation = orientation |> enum<Orientation>
 
+            let! direction        = Json.tryRead "direction"
+
             return 
                 {
                     version         = current
@@ -194,7 +199,9 @@ module ScaleBar =
                     view            = view
                     transformation  = transformation
                     preTransform    = preTransform |> Trafo3d.Parse
-                    direction       = getDirectionVec orientation view
+                    direction       = match direction with
+                                        | Some d -> d |> V3d.Parse
+                                        | None -> getDirectionVec orientation view
                 }
         }
 
@@ -234,6 +241,7 @@ type ScaleBar with
             do! Json.write "view" camView
             do! Json.write "transformation" x.transformation  
             do! Json.write "preTransform" (x.preTransform.ToString())
+            do! Json.write "direction" (x.direction.ToString())
         }
 
 
@@ -367,7 +375,7 @@ module InitScaleBarsParams =
     }
 
     let initialScaleBarDrawing = {
-        orientation     = Orientation.Horizontal
+        orientation     = Orientation.Horizontal_cam
         alignment       = Pivot.Left
         thickness       = thickness
         length          = length

--- a/src/PRo3D.Core/ScaleBars-Model.fs
+++ b/src/PRo3D.Core/ScaleBars-Model.fs
@@ -118,7 +118,7 @@ type ScaleBar = {
     view            : CameraView
     transformation  : Transformations
     preTransform    : Trafo3d
-    direction       : V3d
+    //direction       : V3d
 }
 
 [<ModelType>]
@@ -174,7 +174,7 @@ module ScaleBar =
 
             let orientation = orientation |> enum<Orientation>
 
-            let! direction        = Json.tryRead "direction"
+            //let! direction        = Json.tryRead "direction"
 
             return 
                 {
@@ -199,9 +199,9 @@ module ScaleBar =
                     view            = view
                     transformation  = transformation
                     preTransform    = preTransform |> Trafo3d.Parse
-                    direction       = match direction with
-                                        | Some d -> d |> V3d.Parse
-                                        | None -> getDirectionVec orientation view
+                    //direction       = match direction with
+                    //                    | Some d -> d |> V3d.Parse
+                    //                    | None -> getDirectionVec orientation view
                 }
         }
 
@@ -241,7 +241,7 @@ type ScaleBar with
             do! Json.write "view" camView
             do! Json.write "transformation" x.transformation  
             do! Json.write "preTransform" (x.preTransform.ToString())
-            do! Json.write "direction" (x.direction.ToString())
+            //do! Json.write "direction" (x.direction.ToString())
         }
 
 

--- a/src/PRo3D.Core/ScaleBarsApp.fs
+++ b/src/PRo3D.Core/ScaleBarsApp.fs
@@ -123,6 +123,9 @@ type ScaleBarsAction =
 
 module ScaleBarUtils = 
 
+    let getPlanetBasedUpVector (p:V3d) (planet:Planet) = 
+        CooTransformation.getUpVector p planet
+
     let getLengthInMeter 
         (unit : PRo3D.Core.Unit)
         (length : float)  =
@@ -137,13 +140,15 @@ module ScaleBarUtils =
     let getDirectionVec 
         (orientation : Orientation) 
         (view : CameraView) 
-        (refSys : ReferenceSystem) =  
+        (position : V3d) 
+        (planet : Planet) =  
+            let planetUp = getPlanetBasedUpVector position planet
             match orientation with
             | Orientation.Horizontal_cam    -> view.Right
             | Orientation.Vertical_cam      -> view.Up
             | Orientation.Sky_cam           -> view.Sky
-            | Orientation.Horizontal_planet -> refSys.up.value.Cross(view.Backward)
-            | Orientation.Sky_planet        -> refSys.up.value
+            | Orientation.Horizontal_planet -> planetUp.Cross(view.Backward)
+            | Orientation.Sky_planet        -> planetUp
             |_                       -> view.Right
 
 
@@ -187,20 +192,20 @@ module ScaleBarUtils =
                     segments <- segments |> IndexList.add segment
             segments
 
-    let updateSegments (scaleBar : ScaleBar) =
-        //let direction = getDirectionVec scaleBar.orientation scaleBar.view
+    let updateSegments (scaleBar : ScaleBar) (planet : Planet) =
+        let direction = getDirectionVec scaleBar.orientation scaleBar.view scaleBar.position planet
         let length = getLengthInMeter scaleBar.unit scaleBar.length.value
-        getSegments scaleBar.position length scaleBar.direction scaleBar.alignment ((int)scaleBar.subdivisions.value)
+        getSegments scaleBar.position length direction scaleBar.alignment ((int)scaleBar.subdivisions.value)
 
     let mkScaleBar 
         (drawing : ScaleBarDrawing) 
         (position : V3d) 
         (view : CameraView) 
-        (refSys : ReferenceSystem) =  
+        (planet : Planet) =  
 
             let subdivisions = InitScaleBarsParams.subdivisions // todo via gui
             let length = getLengthInMeter drawing.unit drawing.length.value
-            let direction = getDirectionVec drawing.orientation view refSys
+            let direction = getDirectionVec drawing.orientation view position planet
             let segments = getSegments position length direction drawing.alignment ((int)subdivisions.value)
             let text = drawing.length.value.ToString() + drawing.unit.ToString()
 
@@ -227,7 +232,7 @@ module ScaleBarUtils =
                 transformation  = Init.transformations
                 preTransform    = Trafo3d.Identity
 
-                direction = direction
+                //direction = direction
             }
 
 
@@ -304,7 +309,7 @@ module ScaleBarsApp =
             | None, _ -> model
 
         | AddScaleBar (p,drawing, view) ->
-            let scaleBar = ScaleBarUtils.mkScaleBar drawing p view refSys
+            let scaleBar = ScaleBarUtils.mkScaleBar drawing p view refSys.planet
             let scaleBars' =  HashMap.add scaleBar.guid scaleBar model.scaleBars
             { model with scaleBars = scaleBars'; selectedScaleBar = Some scaleBar.guid }
 
@@ -327,7 +332,7 @@ module ScaleBarsApp =
                 match scB with
                 | Some sb ->
                     let scaleBar = (ScaleBarProperties.update sb msg)
-                    let scaleBar' = { scaleBar with scSegments = ScaleBarUtils.updateSegments scaleBar }
+                    let scaleBar' = { scaleBar with scSegments = ScaleBarUtils.updateSegments scaleBar refSys.planet}
                     let scaleBars = model.scaleBars |> HashMap.alter sb.guid (function | Some _ -> Some scaleBar' | None -> None )
                     { model with scaleBars = scaleBars} 
                 | None -> model
@@ -487,8 +492,7 @@ module ScaleBarsApp =
             } |> Sg.dynamic
 
         let getSgSegmentLine
-            (segment : AdaptivescSegment) 
-            //(trafo : aval<Trafo3d>)
+            (segment : AdaptivescSegment)
             (thickness : aval<float>) =
             adaptive {
                 let! p1 = segment.startPoint
@@ -503,15 +507,16 @@ module ScaleBarsApp =
 
         let getP1P2 
             (scaleBar   : AdaptiveScaleBar) 
-            (refsys : AdaptiveReferenceSystem)=
+            (planet     : aval<Planet>)=
             aval {
                 let! position = scaleBar.position
                 let! length = scaleBar.length.value
                 let! unit = scaleBar.unit
                 let length' = ScaleBarUtils.getLengthInMeter unit length
-                //let! orientation = scaleBar.orientation
-                //let! view = scaleBar.view
-                let! direction = scaleBar.direction //ScaleBarUtils.getDirectionVec orientation view
+                let! orientation = scaleBar.orientation
+                let! view = scaleBar.view
+                let! planet = planet
+                let direction = ScaleBarUtils.getDirectionVec orientation view position planet
                 let! alignment = scaleBar.alignment
                 let p1 = ScaleBarUtils.getP1 position length' direction alignment
                     
@@ -523,16 +528,18 @@ module ScaleBarsApp =
             (scaleBar   : AdaptiveScaleBar) 
             (view       : aval<CameraView>)
             (near       : aval<float>)
-            (hfov       : aval<float>) =
+            (hfov       : aval<float>) 
+            (planet     : aval<Planet>) =
 
             let labelPosition =
                 adaptive {
                     let! scaleBar = scaleBar.Current
-
                     let pos = scaleBar.position
+                    let! planet = planet
+                    let direction = ScaleBarUtils.getDirectionVec scaleBar.orientation scaleBar.view pos planet
 
                     let scaledDirection = 
-                        scaleBar.direction * ((scaleBar.length.value / 2.0) |> ScaleBarUtils.getLengthInMeter scaleBar.unit )
+                        direction * ((scaleBar.length.value / 2.0) |> ScaleBarUtils.getLengthInMeter scaleBar.unit )
 
                     match scaleBar.alignment with
                     | Pivot.Left   -> return pos + scaledDirection
@@ -557,7 +564,8 @@ module ScaleBarsApp =
             (scaleBarsModel : AdaptiveScaleBarsModel) 
             (view           : aval<CameraView>)
             (mbigConfig     : 'ma)
-            (minnerConfig   : MInnerConfig<'ma>) =
+            (minnerConfig   : MInnerConfig<'ma>) 
+            (planet         : aval<Planet>) =
 
             let near = minnerConfig.getNearDistance mbigConfig
 
@@ -566,7 +574,7 @@ module ScaleBarsApp =
             
             scaleBars 
             |> AMap.map( fun id sb ->
-                viewSingleText sb view near hfov
+                viewSingleText sb view near hfov planet
             )
             |> AMap.toASet 
             |> ASet.map snd 
@@ -639,8 +647,7 @@ module ScaleBarsApp =
             (scaleBarsModel : AdaptiveScaleBarsModel) 
             (view           : aval<CameraView>)
             (mbigConfig     : 'ma)
-            (minnerConfig   : MInnerConfig<'ma>)
-            (refsys         : AdaptiveReferenceSystem) =
+            (minnerConfig   : MInnerConfig<'ma>) =
 
             let near = minnerConfig.getNearDistance mbigConfig
 
@@ -652,7 +659,6 @@ module ScaleBarsApp =
                 viewSingleScaleBarCylinder
                     sb
                     view
-                    //refsys
                     near
                     selected
             )

--- a/src/PRo3D.Viewer/Scene.fs
+++ b/src/PRo3D.Viewer/Scene.fs
@@ -272,7 +272,7 @@ module SceneLoader =
     let addScaleBarSegments (m:Model) = 
         m.scene.scaleBars.scaleBars
         |> HashMap.map( fun id sb -> 
-                let segments = ScaleBarUtils.updateSegments sb
+                let segments = ScaleBarUtils.updateSegments sb m.scene.referenceSystem.planet
                 { sb with scSegments = segments})
         |> (flip <| Optic.set _scaleBarsLens) m
 

--- a/src/PRo3D.Viewer/Viewer/SnapshotSg.fs
+++ b/src/PRo3D.Viewer/Viewer/SnapshotSg.fs
@@ -284,6 +284,7 @@ module SnapshotSg =
                     m.navigation.camera.view 
                     m.scene.config
                     mrefConfig
+                    m.scene.referenceSystem.planet
 
             [
                 exploreCenter; 
@@ -306,7 +307,6 @@ module SnapshotSg =
                 m.navigation.camera.view
                 m.scene.config
                 mrefConfig
-                m.scene.referenceSystem
             |> Sg.map ScaleBarsMessage
 
         let sceneObjects =

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -1934,6 +1934,7 @@ module ViewerApp =
                     m.navigation.camera.view 
                     m.scene.config
                     mrefConfig
+                    m.scene.referenceSystem.planet
 
             [
                 exploreCenter; 
@@ -1984,7 +1985,6 @@ module ViewerApp =
                 m.navigation.camera.view
                 m.scene.config
                 mrefConfig
-                m.scene.referenceSystem
             |> Sg.map ScaleBarsMessage
 
         let sceneObjects =


### PR DESCRIPTION
the scaleBars orientations are updated:

type Orientation = 
| Horizontal_cam     = 0 // right direction of camera view
| Vertical_cam          = 1 // up direction of camera view
| Sky_cam                = 2 // camera sky vector
| Horizontal_planet  = 3 // reference systen plane parallel to right direction of camera view
| Sky_planet             = 4 // up direction of reference system

please also check if the remote part is still correct, I had to update the updateSegments part as well.