### PR TITLE
Reimplemented lod-metric

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -237,7 +237,7 @@ let test = """let viewerVersion       = "3.1.3" """
     res
     *)
 
-let aardiumVersion = "2.0.5"
+let aardiumVersion = "2.1.1"
     //let versions = getInstalledPackageVersions()
     //match Map.tryFind "Aardium" versions with
     //| Some v -> v
@@ -433,7 +433,7 @@ Target.create "Publish" (fun _ ->
         }
     )
 
-    // snapshots
+    //// snapshots
     "src/PRo3D.Snapshots/PRo3D.Snapshots.fsproj" |> DotNet.publish (fun o ->
         { o with
             Framework = Some "net6.0"
@@ -496,7 +496,7 @@ Target.create "Publish" (fun _ ->
         Shell.copyDir (Path.Combine(target, "mac-x64", "tools")) (Path.Combine(tempPath, "tools")) (fun _ -> true)
         Shell.copyDir (Path.Combine(target, "win-x64", "tools")) (Path.Combine(tempPath, "tools")) (fun _ -> true)
 
-        File.Move("bin/publish/win-x64/PRo3D.Viewer.exe", sprintf "bin/publish/win-x64/PRo3D.Viewer.%s.exe" notes.NugetVersion)
+        //File.Move("bin/publish/win-x64/PRo3D.Viewer.exe", sprintf "bin/publish/win-x64/PRo3D.Viewer.%s.exe" notes.NugetVersion)
 )
 
 "Credits" ==> "Publish" |> ignore

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 ## 4.27.0-prerelease3
+- reverted polynomial distance decay for lod.
+
+## 4.27.0-prerelease3
 - fixed wrong picking when using pivot based transformations
 
 ## 4.27.0-prerelease2

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## 4.27.0-prerelease2
+## 4.27.0-prerelease3
 - fixed wrong picking when using pivot based transformations
 
 ## 4.27.0-prerelease2

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 4.27.0-prerelease1
+- coordinate frames as scale bars
+- fixed memory leak for high focal length fulcra
+
 ## 4.26.0-prerelease2 
 - fixed surface priority 
 - improved handling of large trajectories

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 4.27.0-prerelease2
+- fixed lod when switching surfaces visible/invisible (keep invisible opcs in lod, to make fast switching possible)
+
 ## 4.27.0-prerelease1
 - coordinate frames as scale bars
 - fixed memory leak for high focal length fulcra

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 4.27.0-prerelease5
+- fixed screenshot functionality
+
 ## 4.27.0-prerelease4
 - reverted polynomial distance decay for lod. 
 

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-## 4.27.0-prerelease3
-- reverted polynomial distance decay for lod.
+## 4.27.0-prerelease4
+- reverted polynomial distance decay for lod. 
 
 ## 4.27.0-prerelease3
 - fixed wrong picking when using pivot based transformations

--- a/TEST_RELEASE_NOTES.md
+++ b/TEST_RELEASE_NOTES.md
@@ -1,4 +1,7 @@
 ## 4.27.0-prerelease2
+- fixed wrong picking when using pivot based transformations
+
+## 4.27.0-prerelease2
 - fixed lod when switching surfaces visible/invisible (keep invisible opcs in lod, to make fast switching possible)
 
 ## 4.27.0-prerelease1

--- a/src/OpcViewer/Program.fs
+++ b/src/OpcViewer/Program.fs
@@ -11,7 +11,7 @@ type Kind = Scene | Annotations | Solarsystem
 [<EntryPoint>]
 let main argv =
     
-    let kind = Scene
+    let kind = Annotations
 
     let shaler =
         { 
@@ -93,7 +93,7 @@ let main argv =
                 preTransform     = Trafo3d.Identity
                 patchHierarchies = 
                         Seq.delay (fun _ -> 
-                            System.IO.Directory.GetDirectories(@"I:\OPC\Shaler_OPCs_2019\Shaler_Navcam") 
+                            System.IO.Directory.GetDirectories(@"C:\pro3ddata\Shaler_OPCs_2019\Shaler_Navcam") 
                             |> Seq.collect System.IO.Directory.GetDirectories
                         )
                 boundingBox      = Box3d.Parse("[[-2490137.664354247, 2285874.562728135, -271408.476700304], [-2490136.248131170, 2285875.658034266, -271406.605430601]]") 
@@ -103,37 +103,37 @@ let main argv =
                 lodDecider       =  DefaultMetrics.mars2 
             }
 
-        let scene =
-            { 
-                useCompressedTextures = true
-                preTransform     = Trafo3d.Identity
-                patchHierarchies = 
-                        Seq.delay (fun _ -> 
-                            System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
-                            |> Seq.collect System.IO.Directory.GetDirectories
-                        )
-                boundingBox      = Box3d.Parse("[[-15.699694740, 4.338130733, -0.514935397], [-4.960646670, 36.914955133, 5.004174588]]") 
-                near             = 0.1
-                far              = 10000.0
-                speed            = 5.0
-                lodDecider       =  DefaultMetrics.mars2 
-            }
+        //let scene =
+        //    { 
+        //        useCompressedTextures = true
+        //        preTransform     = Trafo3d.Identity
+        //        patchHierarchies = 
+        //                Seq.delay (fun _ -> 
+        //                    System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
+        //                    |> Seq.collect System.IO.Directory.GetDirectories
+        //                )
+        //        boundingBox      = Box3d.Parse("[[-15.699694740, 4.338130733, -0.514935397], [-4.960646670, 36.914955133, 5.004174588]]") 
+        //        near             = 0.1
+        //        far              = 10000.0
+        //        speed            = 5.0
+        //        lodDecider       =  DefaultMetrics.mars2 
+        //    }
 
-        let scene =
-            { 
-                useCompressedTextures = true
-                preTransform     = Trafo3d.Identity
-                patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
-                        |> Seq.collect System.IO.Directory.GetDirectories
-                    )
-                boundingBox      = Box3d.Parse("[[-15.699694740, 4.338130733, -0.514935397], [-4.960646670, 36.914955133, 5.004174588]]") 
-                near             = 0.1
-                far              = 10000.0
-                speed            = 5.0
-                lodDecider       =  DefaultMetrics.mars2 
-            }
+        //let scene =
+        //    { 
+        //        useCompressedTextures = true
+        //        preTransform     = Trafo3d.Identity
+        //        patchHierarchies = 
+        //            Seq.delay (fun _ -> 
+        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\20200220_DinosaurQuarry2") 
+        //                |> Seq.collect System.IO.Directory.GetDirectories
+        //            )
+        //        boundingBox      = Box3d.Parse("[[-15.699694740, 4.338130733, -0.514935397], [-4.960646670, 36.914955133, 5.004174588]]") 
+        //        near             = 0.1
+        //        far              = 10000.0
+        //        speed            = 5.0
+        //        lodDecider       =  DefaultMetrics.mars2 
+        //    }
 
         //let scene =
         //    { 
@@ -149,20 +149,20 @@ let main argv =
         //        lodDecider       =  DefaultMetrics.mars2 
         //    }
 
-        let scene =
-            { 
-                useCompressedTextures = true
-                preTransform     = Trafo3d.Identity
-                patchHierarchies = 
-                    Seq.delay (fun _ -> 
-                        System.IO.Directory.GetDirectories(@"F:\pro3d\data\OpcMcz") 
-                    )
-                boundingBox      = Box3d.Parse("[[699507.902347501, 3142696.785742886, 1072717.259930025], [699508.165976587, 3142697.102699531, 1072717.505653937]]") 
-                near             = 0.1
-                far              = 10000.0
-                speed            = 5.0
-                lodDecider       =  DefaultMetrics.mars2 
-            }
+        //let scene =
+        //    { 
+        //        useCompressedTextures = true
+        //        preTransform     = Trafo3d.Identity
+        //        patchHierarchies = 
+        //            Seq.delay (fun _ -> 
+        //                System.IO.Directory.GetDirectories(@"F:\pro3d\data\OpcMcz") 
+        //            )
+        //        boundingBox      = Box3d.Parse("[[699507.902347501, 3142696.785742886, 1072717.259930025], [699508.165976587, 3142697.102699531, 1072717.505653937]]") 
+        //        near             = 0.1
+        //        far              = 10000.0
+        //        speed            = 5.0
+        //        lodDecider       =  DefaultMetrics.mars2 
+        //    }
 
         //let scene =
         //    { 
@@ -202,6 +202,7 @@ let main argv =
         //let annotations = @"F:\pro3d\data\OpcMcz\singleAnno.pro3d.ann"
         let annotations = @"F:\pro3d\data\OpcMcz\blub.pro3d.ann"
         let annotations = @"F:\pro3d\data\OpcMcz\notworking.pro3d.ann"
+        let annotations = @"C:\pro3ddata\Shaler_OPCs_2019\Shaler_v2_Mastcam_w_Navcam_v18_merged_measurementsV2.pro3d.ann"
         //let annotations = @"F:\pro3d\data\OpcMcz\heavy.pro3d.ann"
         //let annotations = @"F:\pro3d\data\dimorphos\singleanno.pro3d.ann"
 

--- a/src/PRo3D.Base/OutlineEffect.fs
+++ b/src/PRo3D.Base/OutlineEffect.fs
@@ -54,7 +54,7 @@ module OutlineEffect =
       }
 
     // NOTE: sg MUST only hold pure Sg without any modes or shaders!
-    let createForSg (outlineGroup: int) (pass: RenderPass) (color: C4f) sg =
+    let createForSg' (lineWidth : aval<float>) (outlineGroup: int) (pass: RenderPass) (color: C4f) (sg : ISg<_>) =
         let sg = sg |> Sg.uniform "Color" (AVal.constant color)
         
         let mask = 
@@ -79,7 +79,7 @@ module OutlineEffect =
             |> Sg.blendMode (AVal.init BlendMode.Blend)
             |> Sg.fillMode (AVal.init FillMode.Fill)
             |> Sg.pass pass
-            |> Sg.uniform "LineWidth" (AVal.constant 5.0)
+            |> Sg.uniform "LineWidth" lineWidth
             |> Sg.shader {
                 do! DefaultSurfaces.stableTrafo
                 do! Shader.lines
@@ -89,6 +89,10 @@ module OutlineEffect =
             }
         
         [ mask; outline ] |> Sg.ofList
+
+    // NOTE: sg MUST only hold pure Sg without any modes or shaders!
+    let createForSg  (outlineGroup: int) (pass: RenderPass) (color: C4f) (sg : ISg<_>) =
+        createForSg' (AVal.constant 5.0) outlineGroup pass color sg
  
     let createForLine 
         (points: aval<V3d[]>) 

--- a/src/PRo3D.Base/WebClientDeprecation.fs
+++ b/src/PRo3D.Base/WebClientDeprecation.fs
@@ -13,4 +13,4 @@ module Helpers =
             }
 
         member x.DownloadFile(uri : string, filename : string) =
-            x.DownloadFileAsync(uri, filename).RunSynchronously()
+            x.DownloadFileAsync(uri, filename).Wait()

--- a/src/PRo3D.Core/Drawing/Drawing-App.fs
+++ b/src/PRo3D.Core/Drawing/Drawing-App.fs
@@ -636,17 +636,17 @@ module DrawingApp =
                 pickingTolerance = msmallConfig.getPickingTolerance mbigConfig
             }
 
-        let annoSet = 
+        let labels = 
             model.annotations.flat 
-            |> AMap.choose (fun _ y -> y |> tryToAnnotation) // TODO v5: here we collapsed some avals - check correctness
-            |> AMap.toASet
-
-        let labels =              
-            annoSet 
-            |> ASet.map(fun (_,a) ->                                           
-                Sg.finishedAnnotationText a config view                 
-            )
-            |> Sg.set   
+            |> AMap.toASetValues
+            |> ASet.chooseA (fun anno -> 
+                match anno |> tryToAnnotation with
+                | None -> AVal.constant None
+                | Some v -> 
+                    Sg.shouldTextBeRendered v 
+                    |> AVal.map (function | true -> Some (Sg.drawText view config v) | _ -> None)
+               ) 
+            |> Sg.set
 
         labels
 

--- a/src/PRo3D.Core/Drawing/Drawing.Sg.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.Sg.fs
@@ -413,15 +413,11 @@ module Sg =
             dotsAndText
         ] |> optional anno.visible
 
-    let finishedAnnotationText
-         (anno             : AdaptiveAnnotation) 
-         (config           : innerViewConfig)
-         (view             : aval<CameraView>) =
-        
-        anno.text 
-        |> AVal.map3 (fun show visible text -> (String.IsNullOrEmpty text) || (show && visible) ) anno.showText anno.visible
-        |> optionalSet (drawText view config anno)
-        |> Sg.set
+
+    let shouldTextBeRendered (anno : AdaptiveAnnotation) =
+         (anno.text, anno.visible, anno.showText) 
+         |||> AVal.map3 (fun text visible show -> show && visible && not (String.IsNullOrEmpty text))
+
 
     let finishedAnnotation 
         (anno             : AdaptiveAnnotation) 

--- a/src/PRo3D.Core/Drawing/Drawing.Sg.fs
+++ b/src/PRo3D.Core/Drawing/Drawing.Sg.fs
@@ -439,14 +439,7 @@ module Sg =
         //            anno.geometry 
         //            config.offset
         //    )
-     
-        let texts = 
-            anno.text 
-            |> AVal.map2 (fun show text -> (String.IsNullOrEmpty text) || show ) anno.showText
-            |> optionalSet (drawText view config anno)
-    
-        let dotsAndText = texts |> Sg.set //ASet.union' [dots; texts] |> Sg.set
-            
+
         //let selectionColor = AVal.map2(fun x color -> if x then C4b.VRVisGreen else color) picked c
         let pickingAllowed = // for this particular annotation // whether should fire pick actions
             AVal.map2 (&&) pickingAllowed anno.visible

--- a/src/PRo3D.Core/ScaleBars-Model.fs
+++ b/src/PRo3D.Core/ScaleBars-Model.fs
@@ -96,8 +96,12 @@ type scSegment with
             do! Json.write "color" (x.color.ToString())
         }
 
+type ScaleRepresentation =
+    | ScaleBar = 0
+    | CoordinateFrame = 1
+
 [<ModelType>]
-type ScaleBar = {
+type ScaleVisualization = {
     version         : int
     guid            : System.Guid
     name            : string
@@ -120,6 +124,8 @@ type ScaleBar = {
     transformation  : Transformations
     preTransform    : Trafo3d
     //direction       : V3d
+
+    representation : ScaleRepresentation
 }
 
 [<ModelType>]
@@ -175,6 +181,10 @@ module ScaleBar =
 
             let orientation = orientation |> enum<Orientation>
 
+            let! representation = 
+                Json.tryRead "representation" 
+
+
             //let! direction        = Json.tryRead "direction"
 
             return 
@@ -200,14 +210,12 @@ module ScaleBar =
                     view            = view
                     transformation  = transformation
                     preTransform    = preTransform |> Trafo3d.Parse
-                    //direction       = match direction with
-                    //                    | Some d -> d |> V3d.Parse
-                    //                    | None -> getDirectionVec orientation view
+                    representation  = representation |> Option.map enum<ScaleRepresentation> |> Option.defaultValue ScaleRepresentation.ScaleBar 
                 }
         }
 
-type ScaleBar with
-    static member FromJson(_ : ScaleBar) =
+type ScaleVisualization with
+    static member FromJson(_ : ScaleVisualization) =
         json {
             let! v = Json.read "version"
             match v with 
@@ -217,7 +225,7 @@ type ScaleBar with
                 |> sprintf "don't know version %A  of ScaleBar"
                 |> Json.error
         }
-    static member ToJson(x : ScaleBar) =
+    static member ToJson(x : ScaleVisualization) =
         json {
             do! Json.write "version" x.version
             do! Json.write "guid" x.guid
@@ -242,6 +250,7 @@ type ScaleBar with
             do! Json.write "view" camView
             do! Json.write "transformation" x.transformation  
             do! Json.write "preTransform" (x.preTransform.ToString())
+            do! Json.write "representation" (int x.representation)
             //do! Json.write "direction" (x.direction.ToString())
         }
 
@@ -249,7 +258,7 @@ type ScaleBar with
 [<ModelType>]
 type ScaleBarsModel = {
     version          : int
-    scaleBars        : HashMap<Guid,ScaleBar>
+    scaleBars        : HashMap<Guid,ScaleVisualization>
     selectedScaleBar : Option<Guid> 
 }
 
@@ -259,7 +268,7 @@ module ScaleBarsModel =
     let read0 = 
         json {
             let! scaleBars = Json.read "scaleBars"
-            let scaleBars = scaleBars |> List.map(fun (a : ScaleBar) -> (a.guid, a)) |> HashMap.ofList
+            let scaleBars = scaleBars |> List.map(fun (a : ScaleVisualization) -> (a.guid, a)) |> HashMap.ofList
 
             let! selected     = Json.read "selectedScaleBar"
             return 

--- a/src/PRo3D.Core/ScaleBars-Model.g.fs
+++ b/src/PRo3D.Core/ScaleBars-Model.g.fs
@@ -1,5 +1,5 @@
-//27ac5532-ddb7-01d9-9019-b717235c0777
-//652ff85a-951e-e7c3-8a3d-31cd4ac20715
+//55ffe839-1706-fe94-127c-a66d739541fc
+//6e02a380-6769-a0ff-1f49-6d0a6d57d862
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -37,7 +37,7 @@ module scSegmentLenses =
         static member endPoint_ = ((fun (self : scSegment) -> self.endPoint), (fun (value : Aardvark.Base.V3d) (self : scSegment) -> { self with endPoint = value }))
         static member color_ = ((fun (self : scSegment) -> self.color), (fun (value : Aardvark.Base.C4b) (self : scSegment) -> { self with color = value }))
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
-type AdaptiveScaleBar(value : ScaleBar) =
+type AdaptiveScaleVisualization(value : ScaleVisualization) =
     let _version_ = FSharp.Data.Adaptive.cval(value.version)
     let _guid_ = FSharp.Data.Adaptive.cval(value.guid)
     let _name_ = FSharp.Data.Adaptive.cval(value.name)
@@ -60,12 +60,13 @@ type AdaptiveScaleBar(value : ScaleBar) =
     let _view_ = FSharp.Data.Adaptive.cval(value.view)
     let _transformation_ = PRo3D.Core.Surface.AdaptiveTransformations(value.transformation)
     let _preTransform_ = FSharp.Data.Adaptive.cval(value.preTransform)
+    let _representation_ = FSharp.Data.Adaptive.cval(value.representation)
     let mutable __value = value
     let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
-    static member Create(value : ScaleBar) = AdaptiveScaleBar(value)
-    static member Unpersist = Adaptify.Unpersist.create (fun (value : ScaleBar) -> AdaptiveScaleBar(value)) (fun (adaptive : AdaptiveScaleBar) (value : ScaleBar) -> adaptive.Update(value))
-    member __.Update(value : ScaleBar) =
-        if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<ScaleBar>.ShallowEquals(value, __value))) then
+    static member Create(value : ScaleVisualization) = AdaptiveScaleVisualization(value)
+    static member Unpersist = Adaptify.Unpersist.create (fun (value : ScaleVisualization) -> AdaptiveScaleVisualization(value)) (fun (adaptive : AdaptiveScaleVisualization) (value : ScaleVisualization) -> adaptive.Update(value))
+    member __.Update(value : ScaleVisualization) =
+        if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<ScaleVisualization>.ShallowEquals(value, __value))) then
             __value <- value
             __adaptive.MarkOutdated()
             _version_.Value <- value.version
@@ -86,6 +87,7 @@ type AdaptiveScaleBar(value : ScaleBar) =
             _view_.Value <- value.view
             _transformation_.Update(value.transformation)
             _preTransform_.Value <- value.preTransform
+            _representation_.Value <- value.representation
     member __.Current = __adaptive
     member __.version = _version_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
     member __.guid = _guid_ :> FSharp.Data.Adaptive.aval<System.Guid>
@@ -105,27 +107,29 @@ type AdaptiveScaleBar(value : ScaleBar) =
     member __.view = _view_ :> FSharp.Data.Adaptive.aval<Aardvark.Rendering.CameraView>
     member __.transformation = _transformation_
     member __.preTransform = _preTransform_ :> FSharp.Data.Adaptive.aval<Aardvark.Base.Trafo3d>
+    member __.representation = _representation_ :> FSharp.Data.Adaptive.aval<ScaleRepresentation>
 [<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
-module ScaleBarLenses = 
-    type ScaleBar with
-        static member version_ = ((fun (self : ScaleBar) -> self.version), (fun (value : Microsoft.FSharp.Core.int) (self : ScaleBar) -> { self with version = value }))
-        static member guid_ = ((fun (self : ScaleBar) -> self.guid), (fun (value : System.Guid) (self : ScaleBar) -> { self with guid = value }))
-        static member name_ = ((fun (self : ScaleBar) -> self.name), (fun (value : Microsoft.FSharp.Core.string) (self : ScaleBar) -> { self with name = value }))
-        static member text_ = ((fun (self : ScaleBar) -> self.text), (fun (value : Microsoft.FSharp.Core.string) (self : ScaleBar) -> { self with text = value }))
-        static member textsize_ = ((fun (self : ScaleBar) -> self.textsize), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleBar) -> { self with textsize = value }))
-        static member textVisible_ = ((fun (self : ScaleBar) -> self.textVisible), (fun (value : Microsoft.FSharp.Core.bool) (self : ScaleBar) -> { self with textVisible = value }))
-        static member isVisible_ = ((fun (self : ScaleBar) -> self.isVisible), (fun (value : Microsoft.FSharp.Core.bool) (self : ScaleBar) -> { self with isVisible = value }))
-        static member position_ = ((fun (self : ScaleBar) -> self.position), (fun (value : Aardvark.Base.V3d) (self : ScaleBar) -> { self with position = value }))
-        static member scSegments_ = ((fun (self : ScaleBar) -> self.scSegments), (fun (value : FSharp.Data.Adaptive.IndexList<scSegment>) (self : ScaleBar) -> { self with scSegments = value }))
-        static member orientation_ = ((fun (self : ScaleBar) -> self.orientation), (fun (value : Orientation) (self : ScaleBar) -> { self with orientation = value }))
-        static member alignment_ = ((fun (self : ScaleBar) -> self.alignment), (fun (value : Pivot) (self : ScaleBar) -> { self with alignment = value }))
-        static member thickness_ = ((fun (self : ScaleBar) -> self.thickness), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleBar) -> { self with thickness = value }))
-        static member length_ = ((fun (self : ScaleBar) -> self.length), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleBar) -> { self with length = value }))
-        static member unit_ = ((fun (self : ScaleBar) -> self.unit), (fun (value : Unit) (self : ScaleBar) -> { self with unit = value }))
-        static member subdivisions_ = ((fun (self : ScaleBar) -> self.subdivisions), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleBar) -> { self with subdivisions = value }))
-        static member view_ = ((fun (self : ScaleBar) -> self.view), (fun (value : Aardvark.Rendering.CameraView) (self : ScaleBar) -> { self with view = value }))
-        static member transformation_ = ((fun (self : ScaleBar) -> self.transformation), (fun (value : PRo3D.Core.Surface.Transformations) (self : ScaleBar) -> { self with transformation = value }))
-        static member preTransform_ = ((fun (self : ScaleBar) -> self.preTransform), (fun (value : Aardvark.Base.Trafo3d) (self : ScaleBar) -> { self with preTransform = value }))
+module ScaleVisualizationLenses = 
+    type ScaleVisualization with
+        static member version_ = ((fun (self : ScaleVisualization) -> self.version), (fun (value : Microsoft.FSharp.Core.int) (self : ScaleVisualization) -> { self with version = value }))
+        static member guid_ = ((fun (self : ScaleVisualization) -> self.guid), (fun (value : System.Guid) (self : ScaleVisualization) -> { self with guid = value }))
+        static member name_ = ((fun (self : ScaleVisualization) -> self.name), (fun (value : Microsoft.FSharp.Core.string) (self : ScaleVisualization) -> { self with name = value }))
+        static member text_ = ((fun (self : ScaleVisualization) -> self.text), (fun (value : Microsoft.FSharp.Core.string) (self : ScaleVisualization) -> { self with text = value }))
+        static member textsize_ = ((fun (self : ScaleVisualization) -> self.textsize), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleVisualization) -> { self with textsize = value }))
+        static member textVisible_ = ((fun (self : ScaleVisualization) -> self.textVisible), (fun (value : Microsoft.FSharp.Core.bool) (self : ScaleVisualization) -> { self with textVisible = value }))
+        static member isVisible_ = ((fun (self : ScaleVisualization) -> self.isVisible), (fun (value : Microsoft.FSharp.Core.bool) (self : ScaleVisualization) -> { self with isVisible = value }))
+        static member position_ = ((fun (self : ScaleVisualization) -> self.position), (fun (value : Aardvark.Base.V3d) (self : ScaleVisualization) -> { self with position = value }))
+        static member scSegments_ = ((fun (self : ScaleVisualization) -> self.scSegments), (fun (value : FSharp.Data.Adaptive.IndexList<scSegment>) (self : ScaleVisualization) -> { self with scSegments = value }))
+        static member orientation_ = ((fun (self : ScaleVisualization) -> self.orientation), (fun (value : Orientation) (self : ScaleVisualization) -> { self with orientation = value }))
+        static member alignment_ = ((fun (self : ScaleVisualization) -> self.alignment), (fun (value : Pivot) (self : ScaleVisualization) -> { self with alignment = value }))
+        static member thickness_ = ((fun (self : ScaleVisualization) -> self.thickness), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleVisualization) -> { self with thickness = value }))
+        static member length_ = ((fun (self : ScaleVisualization) -> self.length), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleVisualization) -> { self with length = value }))
+        static member unit_ = ((fun (self : ScaleVisualization) -> self.unit), (fun (value : Unit) (self : ScaleVisualization) -> { self with unit = value }))
+        static member subdivisions_ = ((fun (self : ScaleVisualization) -> self.subdivisions), (fun (value : Aardvark.UI.Primitives.NumericInput) (self : ScaleVisualization) -> { self with subdivisions = value }))
+        static member view_ = ((fun (self : ScaleVisualization) -> self.view), (fun (value : Aardvark.Rendering.CameraView) (self : ScaleVisualization) -> { self with view = value }))
+        static member transformation_ = ((fun (self : ScaleVisualization) -> self.transformation), (fun (value : PRo3D.Core.Surface.Transformations) (self : ScaleVisualization) -> { self with transformation = value }))
+        static member preTransform_ = ((fun (self : ScaleVisualization) -> self.preTransform), (fun (value : Aardvark.Base.Trafo3d) (self : ScaleVisualization) -> { self with preTransform = value }))
+        static member representation_ = ((fun (self : ScaleVisualization) -> self.representation), (fun (value : ScaleRepresentation) (self : ScaleVisualization) -> { self with representation = value }))
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveScaleBarDrawing(value : ScaleBarDrawing) =
     let _orientation_ = FSharp.Data.Adaptive.cval(value.orientation)
@@ -164,10 +168,10 @@ module ScaleBarDrawingLenses =
 type AdaptiveScaleBarsModel(value : ScaleBarsModel) =
     let _version_ = FSharp.Data.Adaptive.cval(value.version)
     let _scaleBars_ =
-        let inline __arg2 (m : AdaptiveScaleBar) (v : ScaleBar) =
+        let inline __arg2 (m : AdaptiveScaleVisualization) (v : ScaleVisualization) =
             m.Update(v)
             m
-        FSharp.Data.Traceable.ChangeableModelMap(value.scaleBars, (fun (v : ScaleBar) -> AdaptiveScaleBar(v)), __arg2, (fun (m : AdaptiveScaleBar) -> m))
+        FSharp.Data.Traceable.ChangeableModelMap(value.scaleBars, (fun (v : ScaleVisualization) -> AdaptiveScaleVisualization(v)), __arg2, (fun (m : AdaptiveScaleVisualization) -> m))
     let _selectedScaleBar_ = FSharp.Data.Adaptive.cval(value.selectedScaleBar)
     let mutable __value = value
     let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
@@ -182,12 +186,12 @@ type AdaptiveScaleBarsModel(value : ScaleBarsModel) =
             _selectedScaleBar_.Value <- value.selectedScaleBar
     member __.Current = __adaptive
     member __.version = _version_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.int>
-    member __.scaleBars = _scaleBars_ :> FSharp.Data.Adaptive.amap<System.Guid, AdaptiveScaleBar>
+    member __.scaleBars = _scaleBars_ :> FSharp.Data.Adaptive.amap<System.Guid, AdaptiveScaleVisualization>
     member __.selectedScaleBar = _selectedScaleBar_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.Option<System.Guid>>
 [<AutoOpen; System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 module ScaleBarsModelLenses = 
     type ScaleBarsModel with
         static member version_ = ((fun (self : ScaleBarsModel) -> self.version), (fun (value : Microsoft.FSharp.Core.int) (self : ScaleBarsModel) -> { self with version = value }))
-        static member scaleBars_ = ((fun (self : ScaleBarsModel) -> self.scaleBars), (fun (value : FSharp.Data.Adaptive.HashMap<System.Guid, ScaleBar>) (self : ScaleBarsModel) -> { self with scaleBars = value }))
+        static member scaleBars_ = ((fun (self : ScaleBarsModel) -> self.scaleBars), (fun (value : FSharp.Data.Adaptive.HashMap<System.Guid, ScaleVisualization>) (self : ScaleBarsModel) -> { self with scaleBars = value }))
         static member selectedScaleBar_ = ((fun (self : ScaleBarsModel) -> self.selectedScaleBar), (fun (value : Microsoft.FSharp.Core.Option<System.Guid>) (self : ScaleBarsModel) -> { self with selectedScaleBar = value }))
 

--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.g.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.g.fs
@@ -1,5 +1,5 @@
 //6d8cd910-4dda-ff00-b5b9-3124d680763e
-//3c8b49e2-8409-5ae6-0249-2d61ef7d14b6
+//27fed84a-92a3-c0f8-2bf4-85ad9cadf2db
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -12,11 +12,11 @@ open Adaptify
 open PRo3D.Core.SequencedBookmarks
 [<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
 type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
-    let mutable _cameraView_ = FSharp.Data.Adaptive.cval(value.cameraView)
-    let mutable _name_ = FSharp.Data.Adaptive.cval(value.name)
-    let mutable _key_ = FSharp.Data.Adaptive.cval(value.key)
     let mutable _path_ = FSharp.Data.Adaptive.cval(value.path)
+    let mutable _key_ = FSharp.Data.Adaptive.cval(value.key)
+    let mutable _cameraView_ = FSharp.Data.Adaptive.cval(value.cameraView)
     let mutable _filename_ = FSharp.Data.Adaptive.cval(value.filename)
+    let mutable _name_ = FSharp.Data.Adaptive.cval(value.name)
     let _bookmark_ = PRo3D.Core.AdaptiveBookmark(value.bookmark)
     let _metadata_ = FSharp.Data.Adaptive.cval(value.metadata)
     let _frustumParameters_ = FSharp.Data.Adaptive.cval(value.frustumParameters)
@@ -41,11 +41,11 @@ type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
         if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<SequencedBookmarkModel>.ShallowEquals(value, __value))) then
             __value <- value
             __adaptive.MarkOutdated()
-            _cameraView_.Value <- value.cameraView
-            _name_.Value <- value.name
-            _key_.Value <- value.key
             _path_.Value <- value.path
+            _key_.Value <- value.key
+            _cameraView_.Value <- value.cameraView
             _filename_.Value <- value.filename
+            _name_.Value <- value.name
             _bookmark_.Update(value.bookmark)
             _metadata_.Value <- value.metadata
             _frustumParameters_.Value <- value.frustumParameters
@@ -56,11 +56,11 @@ type AdaptiveSequencedBookmarkModel(value : SequencedBookmarkModel) =
             _duration_.Update(value.duration)
             _observationInfo_.Update(value.observationInfo)
     member __.Current = __adaptive
-    member __.cameraView = _cameraView_ :> FSharp.Data.Adaptive.aval<Aardvark.Rendering.CameraView>
-    member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
-    member __.key = _key_ :> FSharp.Data.Adaptive.aval<System.Guid>
     member __.path = _path_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+    member __.key = _key_ :> FSharp.Data.Adaptive.aval<System.Guid>
+    member __.cameraView = _cameraView_ :> FSharp.Data.Adaptive.aval<Aardvark.Rendering.CameraView>
     member __.filename = _filename_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+    member __.name = _name_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
     member __.version = __value.version
     member __.bookmark = _bookmark_
     member __.metadata = _metadata_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.option<Microsoft.FSharp.Core.string>>

--- a/src/PRo3D.Core/Surface/Surface.Sg.fs
+++ b/src/PRo3D.Core/Surface/Surface.Sg.fs
@@ -195,7 +195,7 @@ module Sg =
                 let dist    = (closest - campPos).Length
 
                 let unitPxSize = (lodParams.frustum.right - lodParams.frustum.left) / (float lodParams.size.X * 0.5)
-                let px = (0.1 * renderPatch.triangleSize) / (pow dist 1.2) // (pow dist 1.2) // (added pow 1.2 here... discuss)
+                let px = (0.1 * renderPatch.triangleSize) / dist // (pow dist 1.2) // (added pow 1.2 here... discuss)
 
                 // Log.warn "%f to %f - avgSize: %f" px (unitPxSize * lodParams.factor) p.triangleSize
                 px > unitPxSize * (exp lodParams.factor)

--- a/src/PRo3D.Core/Surface/Surface.Sg.fs
+++ b/src/PRo3D.Core/Surface/Surface.Sg.fs
@@ -175,8 +175,10 @@ module Sg =
         (isActive    : aval<bool>)
         =
 
-        let isRenderingActive = isActive.GetValue self
-        if isRenderingActive then
+        let isRenderingActive = 
+            //isActive.GetValue self, using isActive (actually is invisible) is not possible here, see https://github.com/pro3d-space/PRo3D/issues/484
+            true
+        if isRenderingActive  then
             let lodParams = lodParams.GetValue self
             let viewTrafo = viewTrafo.GetValue self
             let model = preTrafo * renderPatch.trafo.GetValue self

--- a/src/PRo3D.Core/TransformationApp.fs
+++ b/src/PRo3D.Core/TransformationApp.fs
@@ -64,13 +64,13 @@ module TransformationApp =
             
             //let upP = CooTransformation.getUpVector transform.pivot.value refsys.planet
             let upP = CooTransformation.getUpVector pivot refsys.planet
-            let eastP = V3d.OOI.Cross(upP)
+            let eastP = V3d.OOI.Cross(upP.Normalized).Normalized
         
             let northP  = 
                 match refsys.planet with 
                 | Planet.None | Planet.JPL -> V3d.IOO
                 | Planet.ENU -> V3d.OIO
-                | _ -> upP.Cross(eastP) 
+                | _ -> upP.Cross(eastP).Normalized 
 
             let noP = 
                 Rot3d.Rotation(upP, refsys.noffset.value |> Double.radiansFromDegrees).Transform(northP)

--- a/src/PRo3D.Viewer/InitialViewerModel.fs
+++ b/src/PRo3D.Viewer/InitialViewerModel.fs
@@ -73,6 +73,9 @@ module Viewer =
         //let defaultDashboard = DashboardModes.provenance
         let defaultDockConfig = defaultDashboard.dockConfig //DockConfigs.m2020    
         let viewConfigModel = ViewConfigModel.initial 
+
+        let applyProvenaceIfEnabled (m : Model) =
+            ProvenanceApp.emptyWithModel startupArgs.enableProvenanceTracking m
         {     
             scene = 
                 {
@@ -172,6 +175,6 @@ module Viewer =
             animator            = Animation.Animator.initial animatorLens
 
             provenanceModel = ProvenanceModel.invalid
-        } |> ProvenanceApp.emptyWithModel
+        } |> applyProvenaceIfEnabled
 
 

--- a/src/PRo3D.Viewer/Program.fs
+++ b/src/PRo3D.Viewer/Program.fs
@@ -368,7 +368,13 @@ let main argv =
                 choose []
 
         let suaveServer = 
-            WebPart.startServer port [
+            let startServer = 
+                if startupArgs.enableRemoteApi then 
+                    WebPart.startServer
+                else   
+                    WebPart.startServerLocalhost
+
+            startServer port [
                 if startupArgs.disableCors then allow_cors
                 MutableApp.toWebPart' runtime false mainApp
                 path "/websocket" >=> handShake ws

--- a/src/PRo3D.Viewer/Program.fs
+++ b/src/PRo3D.Viewer/Program.fs
@@ -52,7 +52,7 @@ type Result =
       result : string;
    }
 
-let viewerVersion       = "4.26.0-prerelease1"
+let viewerVersion       = "4.27.0-prerelease1"
 let catchDomainErrors   = false
 
 open System.IO

--- a/src/PRo3D.Viewer/ProvenanceApp.fs
+++ b/src/PRo3D.Viewer/ProvenanceApp.fs
@@ -90,23 +90,25 @@ module ProvenanceApp =
         }
 
     
-    let emptyWithModel (m : Model) = 
+    let emptyWithModel (enabled : bool) (m : Model) = 
+        if enabled then
+            let i = { id = ProvenanceModel.newNodeId(); model = reduceModel m |> Some }
         
-        let i = { id = ProvenanceModel.newNodeId(); model = reduceModel m |> Some }
-        
-        let pm = { 
-            nodes = HashMap.ofList [i.id, i]
-            edges = HashMap.empty; lastEdge = None
-            automaticRecording = false
-            currentTrail = []
-            selectedNode = None
-            initialNode = Some i.id
-        }
+            let pm = { 
+                nodes = HashMap.ofList [i.id, i]
+                edges = HashMap.empty; lastEdge = None
+                automaticRecording = false
+                currentTrail = []
+                selectedNode = None
+                initialNode = Some i.id
+            }
 
 
-        { m with 
-            provenanceModel = pm
-        }
+            { m with 
+                provenanceModel = pm
+            }
+        else    
+            m
 
     let track (oldModel : Model) (newModel : Model) (msg : ViewerAnimationAction) : Model =
         if newModel.provenanceModel.automaticRecording then

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -1099,7 +1099,6 @@ module ViewerApp =
                     m.screenshotDirectory
                     _animator
                     m.viewerVersion
-                |> ProvenanceApp.emptyWithModel
 
             { initialModel with recent = m.recent} |> ViewerIO.loadRoverData
 
@@ -2219,7 +2218,7 @@ module ViewerApp =
             if startEmpty |> not then
                 PRo3D.Viewer.Viewer.initial messagingMailbox StartupArgs.initArgs renderingUrl 
                                             dataSamples screenshotDirectory _animator viewerVersion
-                |> ProvenanceApp.emptyWithModel
+                |> ProvenanceApp.emptyWithModel enableProvenance
                 |> SceneLoader.loadLastScene runtime signature                
                 |> SceneLoader.loadLogBrush
                 |> ViewerIO.loadRoverData                
@@ -2235,7 +2234,7 @@ module ViewerApp =
             else
                 PRo3D.Viewer.Viewer.initial messagingMailbox StartupArgs.initArgs renderingUrl
                                             dataSamples screenshotDirectory _animator viewerVersion
-                |> ProvenanceApp.emptyWithModel
+                |> ProvenanceApp.emptyWithModel enableProvenance
                 |> ViewerIO.loadRoverData
 
         let app = {

--- a/src/PRo3D.Viewer/Viewer/ViewerLenses.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerLenses.fs
@@ -110,7 +110,7 @@ module ViewerLenses =
             let scaleBars = // check scale bars; using old segments for performance reasons
                 if haveSameKeys state.stateScaleBars.scaleBars
                                 m.scene.scaleBars.scaleBars then 
-                    let inline update (newBar : ScaleBar) = 
+                    let inline update (newBar : ScaleVisualization) = 
                         let current = HashMap.tryFind newBar.guid m.scene.scaleBars.scaleBars
                         match current with
                         | Some current ->


### PR DESCRIPTION
There are still two major problems, which cannot be tackled without reworking larger parts of the rendering code:
- for large zoom's many patches get considered due to their poor AABB and cannot be sorted out without more metadata or data-guided LoD.
- the new lod metric uses triangle size as estimate for geometric complexity. oddly sized huge triangles in patches increace the average triangle size leading to large memory footprint without providing additional detail in areas of large triangles. as a workaround i use the old lod metric also to at least not pull in more data as before the PR (i'm not happy with it but there is no time reworking really large parts and re-computing meta-data)