### PR TITLE
Bugfix for issue #456 

### DIFF
--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.fs
@@ -626,7 +626,7 @@ module SequencedBookmark =
                         |> Json.deserialize
                 Some loadedBookmark
             with e ->
-                Log.error "[SequencedBookmarks] Error Loading Bookmark %s" m.path
+                Log.error "[SequencedBookmarks] Error Loading Bookmark %s. When copying or moving a scene in the file system, make sure to also copy the folder with the same name as your scene. The sequenced bookmarks are stored in that folder." m.path
                 Log.error "%s" e.Message
                 None
         | SequencedBookmark.LoadedBookmark m ->

--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarksApp.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarksApp.fs
@@ -109,37 +109,37 @@ module SequencedBookmarksApp =
         (m                : SequencedBookmarks) 
         (act              : SequencedBookmarksAction) 
         (lenses           : BookmarkLenses<'a>)
-        (outerModel       : 'a) : ('a * SequencedBookmarks) =
+        (viewer       : 'a) : ('a * SequencedBookmarks) =
 
         match act with
         | AnimationSettingsMessage msg ->
             let animationSettings = AnimationSettings.update m.animationSettings msg
             let m = {m with animationSettings = animationSettings}
-            outerModel, m
+            viewer, m
         | LoadBookmarks -> 
-            outerModel, BookmarkUtils.loadAll m
+            viewer, BookmarkUtils.loadAll m
         | SaveAnimation ->
             // do in outer model
-            outerModel, m
+            viewer, m
         | AddSBookmark ->
-            let nav = Optic.get lenses.navigationModel_ outerModel
-            let state = Optic.get lenses.sceneState_ outerModel
+            let nav = Optic.get lenses.navigationModel_ viewer
+            let state = Optic.get lenses.sceneState_ viewer
             let newSBm = 
                 getNewSBookmark nav (BookmarkUtils.getValidState state)  m.bookmarks.Count None
             let m = addBookmark newSBm m
-            outerModel, m
+            viewer, m
         | AddGisBookmark ->
-            let nav = Optic.get lenses.navigationModel_ outerModel
-            let state = Optic.get lenses.sceneState_ outerModel
+            let nav = Optic.get lenses.navigationModel_ viewer
+            let state = Optic.get lenses.sceneState_ viewer
             let defaultInfo = 
-                Optic.get lenses.defaultObservationInfo_ outerModel
+                Optic.get lenses.defaultObservationInfo_ viewer
                 |> Some
             let newSBm = 
                 getNewSBookmark nav state  m.bookmarks.Count defaultInfo
             let m = addBookmark newSBm m
-            outerModel, m
+            viewer, m
         | SequencedBookmarksAction.FlyToSBM id ->
-            toBookmarkFromView m outerModel lenses (tryFind id)
+            toBookmarkFromView m viewer lenses (tryFind id)
         | RemoveSBM id -> 
             let selSBm = 
                 match m.selectedBookmark with
@@ -149,9 +149,9 @@ module SequencedBookmarksApp =
             let bookmarks' = m.bookmarks |> HashMap.remove id
             let index = m.orderList |> List.toSeq |> Seq.findIndex(fun x -> x = id)
             let orderList' = removeGuid index m.orderList 
-            outerModel, { m with bookmarks = bookmarks'
-                                 orderList = orderList'
-                                 selectedBookmark = selSBm         
+            viewer, { m with bookmarks = bookmarks'
+                             orderList = orderList'
+                             selectedBookmark = selSBm         
                         }
        
         | SelectSBM id ->
@@ -163,31 +163,31 @@ module SequencedBookmarksApp =
                     match selected with
                     | Some sel -> // apply bookmark state
                         Optic.set lenses.setModel_ (SequencedBookmark.LoadedBookmark sel)
-                                                   outerModel
+                                                   viewer
                     | None ->
-                        outerModel
+                        viewer
                 outerModel, m
             | false ->
-                outerModel, selectSBookmark m id 
+                viewer, selectSBookmark m id 
         | SetSceneState id ->
             let updState bm =
-                {bm with sceneState = Some (Optic.get lenses.sceneState_ outerModel)}
+                {bm with sceneState = Some (Optic.get lenses.sceneState_ viewer)}
             let m = loadAndUpdate m id updState
             Log.line "[Sequenced Bookmarks] Updated scene state."
-            outerModel, m
+            viewer, m
         | SaveSceneState ->
-            let m = {m with savedSceneState = Some (Optic.get lenses.sceneState_ outerModel)}
+            let m = {m with savedSceneState = Some (Optic.get lenses.sceneState_ viewer)}
             Log.line "[SequencedBookmarks] Saved scene state."
-            outerModel, m
+            viewer, m
         | RestoreSceneState ->
             let outerModel = 
                 match m.savedSceneState with
                 | Some state ->
                     Log.line "[SequencedBookmarks] Restoring scene state."
-                    Optic.set lenses.sceneState_ state outerModel
+                    Optic.set lenses.sceneState_ state viewer
                 | None ->
                     Log.line "[SequencedBookmarks] No scene state to restore."
-                    outerModel
+                    viewer
             outerModel, m
         | MoveUp id ->
             let index = m.orderList |> List.toSeq |> Seq.findIndex(fun x -> x = id)
@@ -210,7 +210,7 @@ module SequencedBookmarksApp =
                             [m.orderList.[index]]@[m.orderList.[index-1]]
                 else
                     m.orderList
-            outerModel, { m with orderList = orderList' }
+            viewer, { m with orderList = orderList' }
 
         | MoveDown id ->
             let index = m.orderList |> List.toSeq |> Seq.findIndex(fun x -> x = id)
@@ -232,14 +232,14 @@ module SequencedBookmarksApp =
                             [m.orderList.[index+1]]@[m.orderList.[index]]
                 else
                     m.orderList
-            outerModel, { m with orderList = orderList' }
+            viewer, { m with orderList = orderList' }
         | SequencedBookmarkMessage (key, msg) ->  
             let m = loadAndUpdate m key (fun sb -> SequencedBookmark.update sb msg)
-            outerModel, m
+            viewer, m
         | Play ->
-            if Animator.exists AnimationSlot.camera outerModel 
-                && Animator.isPaused AnimationSlot.camera outerModel then
-                Animator.startOrResume AnimationSlot.camera outerModel, m
+            if Animator.exists AnimationSlot.camera viewer 
+                && Animator.isPaused AnimationSlot.camera viewer then
+                Animator.startOrResume AnimationSlot.camera viewer, m
             else 
                 match (List.tryHead m.orderList) with
                 | Some firstBookmark ->
@@ -247,56 +247,56 @@ module SequencedBookmarksApp =
                     match m.animationSettings.useGlobalAnimation with
                     | true ->
                         //smoothPathAllBookmarks m lenses outerModel //removed because it does not work with focal length
-                        pathWithPausing m lenses outerModel
+                        pathWithPausing m lenses viewer
                     | false ->
-                        pathWithPausing m lenses outerModel
+                        pathWithPausing m lenses viewer
                 | None ->
                     Log.line "[SequencedBookmarks] There are no sequenced bookmarks."
-                    outerModel, m
+                    viewer, m
         | StepForward -> 
-            toBookmarkFromView m outerModel lenses next
+            toBookmarkFromView m viewer lenses next
         | StepBackward ->
-            toBookmarkFromView m outerModel lenses previous
+            toBookmarkFromView m viewer lenses previous
         | Pause ->
-            let outerModel = Animator.pause AnimationSlot.camera outerModel
+            let outerModel = Animator.pause AnimationSlot.camera viewer
             outerModel, m 
         | Stop ->
-            let outerModel = Animator.stop AnimationSlot.camera outerModel
+            let outerModel = Animator.stop AnimationSlot.camera viewer
             outerModel, m 
         | StartRecording -> 
-            outerModel, {m with 
+            viewer, {m with 
                             savedTimeSteps = []
                             lastSavedBookmark = None
                             isRecording = true
                             currentFps = None
                          }
         | StopRecording -> 
-            outerModel, {m with isRecording = false}
+            viewer, {m with isRecording = false}
         | ToggleGenerateOnStop ->
-            outerModel, {m with generateOnStop = not m.generateOnStop}
+            viewer, {m with generateOnStop = not m.generateOnStop}
         | ToggleUpdateJsonBeforeRendering ->
-            outerModel, {m with updateJsonBeforeRendering = not m.updateJsonBeforeRendering}
+            viewer, {m with updateJsonBeforeRendering = not m.updateJsonBeforeRendering}
         | ToggleDebug ->
-            outerModel, {m with debug = not m.debug}
+            viewer, {m with debug = not m.debug}
         | UpdateJson ->
             // currently updated in Viewer.fs
-            outerModel, m
+            viewer, m
         | GenerateSnapshots -> 
-            outerModel, {m with isGenerating = true}
+            viewer, {m with isGenerating = true}
         | CancelSnapshots ->
-            outerModel, {m with isCancelled = true}
+            viewer, {m with isCancelled = true}
         | SetResolutionX msg ->
-            outerModel, {m with resolutionX = Numeric.update m.resolutionX msg}
+            viewer, {m with resolutionX = Numeric.update m.resolutionX msg}
         | SetResolutionY msg ->
-            outerModel, {m with resolutionY = Numeric.update m.resolutionY msg}
+            viewer, {m with resolutionY = Numeric.update m.resolutionY msg}
         | SetOutputPath str -> 
             let str = 
                 match str with
                 | [] -> SequencedBookmarks.defaultOutputPath ()
                 | head::tail -> head
-            outerModel, {m with outputPath = str}
+            viewer, {m with outputPath = str}
         | SetFpsSetting setting ->
-            outerModel, {m with fpsSetting = setting}
+            viewer, {m with fpsSetting = setting}
         | CheckSnapshotsProcess id ->
             match snapshotProcess with 
             | Some p -> 
@@ -321,9 +321,9 @@ module SequencedBookmarksApp =
                                         isCancelled  = false
                                 }
                         m
-                outerModel, m
+                viewer, m
             | None -> 
-                outerModel, m
+                viewer, m
 
     let addBookmarks (m : SequencedBookmarks) (bookmarks : list<SequencedBookmark>) =
         let bookmarksWithKeys = 

--- a/src/PRo3D.Viewer/Viewer/SceneConverter.fs
+++ b/src/PRo3D.Viewer/Viewer/SceneConverter.fs
@@ -133,6 +133,7 @@ module SceneLoading =
                 |> ViewerIO.loadAnnotations  
                 |> ViewerIO.loadCorrelations
                 |> ViewerIO.loadLastFootPrint
+                |> ViewerIO.loadSequencedBookmarks
                 |> SceneLoader.addScaleBarSegments
                 |> SceneLoader.loadSceneSpiceKernel
                 |> Choice1Of2 

--- a/src/PRo3D.Viewer/Viewer/Viewer.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer.fs
@@ -473,7 +473,7 @@ module ViewerApp =
             |> Optic.set _animationView nav.camera.view
         | NavigationMessage msg, _, _ ->
             m // cases where navigation is blocked by other operations (e.g. animation)
-        | AnimationMessage msg,_,_ ->
+        | AnimationMessage msg,_,_ -> // belongs to deprecated animation
             let m = 
                 match msg with
                 | Tick t when AnimationApp.shouldAnimate m.animations -> 
@@ -1736,7 +1736,6 @@ module ViewerApp =
             //    ()
             //| _ -> 
             //    ()
-
             Animation.Animator.update msg m   
 
         | ProvenanceMessage msg -> 

--- a/src/PRo3D.Viewer/Viewer/ViewerLenses.fs
+++ b/src/PRo3D.Viewer/Viewer/ViewerLenses.fs
@@ -257,7 +257,8 @@ module ViewerLenses =
                             let c = GisApp.lookAtObserver' observationInfo
                             let m = 
                                 match c with 
-                                | Some c -> Optic.set _view c m
+                                | Some c -> 
+                                    Optic.set _view c m
                                 | _ -> m
                             m
                         | None ->


### PR DESCRIPTION
Using a static animation in the form of (Animation.create (fun _ -> src.cameraView)) for the camera pauses leads to different values for some view attributes at runtime during bookmark transitions on the one hand and pauses on the other (but only in the very specific constellation of the test scene).  Replacing that static approach with an interpolation between two identical values removes the bug, although why the original version fails under these circumstances is still unclear. 
Sequenced bookmarks are now always loaded with the scene, not optionally later on.