### PR TITLE
fixed missing traverse state in sequenced bookmarks

### DIFF
--- a/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.fs
+++ b/src/PRo3D.Core/SequencedBookmarks/SequencedBookmarks-Model.fs
@@ -325,7 +325,7 @@ type SceneState with
             do! Json.write "stateGeologicSurfaces" x.stateGeologicSurfaces
             do! Json.write "stateConfig"           x.stateConfig
             do! Json.write "stateReferenceSystem"  x.stateReferenceSystem
-            //do! Json.write "stateTraverse"         x.stateTraverses
+            do! Json.write "stateTraverse"         x.stateTraverses
         }
 
 type FrustumParameters = {


### PR DESCRIPTION
Traverse properties were not stored properly in sequenced bookmarks. this is due to wrong optimizations done approximately last summer when using huge traverses. The whole persistency model needs to be reworked on a conceptual level. Currently we just two choices a) not storing traverse properties or b) having high disk memory footprint. This one goes for (b).