### PR TITLE
Run the HERA SPICE-kernel tests on CI, and fix what that uncovered

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,59 @@ jobs:
       - name: Build
         run: ${{ matrix.run-build }}
 
-      # kernel-independent tests (HERA tests skip themselves via --skip-hera)
+      # kernel-independent tests (HERA tests skip themselves via --skip-hera).
+      # The kernel-backed ones run in the spice-tests job below.
       - name: Test
         run: ${{ matrix.run-tests }}
+
+  # The HERA SPICE tests, which need ~1.3 GB of ESA mission kernels. Linux only, on
+  # purpose: kernels are platform-independent data files, and one cache entry of that
+  # size per OS would crowd the paket caches out of the repository's 10 GB budget.
+  spice-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Dotnet
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache Paket
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.nuget/packages
+            paket-files
+          key: ${{ runner.os }}-paket-${{ hashFiles('paket.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-paket-
+
+      # Keyed on the pins, not on anything ESA controls: publishing a new SKD (which
+      # happens every few weeks) must not invalidate this, and bumping a pin must.
+      # restore-keys hands a pin bump the previous tree, so it refetches one changed
+      # meta-kernel closure instead of all four.
+      - name: Cache SPICE kernels
+        uses: actions/cache@v6
+        with:
+          path: spice
+          key: ${{ runner.os }}-spice-${{ hashFiles('scripts/spice-kernels.pins') }}
+          restore-keys: |
+            ${{ runner.os }}-spice-
+
+      # Runs on a cache hit too: it verifies the restored tree offline against its own
+      # manifest and exits in a second when complete, and repairs a partial restore
+      # instead of letting it fail much later inside CSPICE.
+      - name: Fetch SPICE kernels
+        run: bash scripts/fetch-spice-kernels.sh spice
+
+      - name: Build
+        run: sh ./build.sh
+
+      # Everything, including the HERA tests. Tests needing private data or a GL
+      # context still skip themselves here.
+      - name: Test
+        env:
+          PRO3D_SPICE_KERNELS: ${{ github.workspace }}/spice
+        run: bash ./runAllTests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ testbed-output/
 /__pycache__
 /profileDrawing/__pycache__
 
+# SPICE kernels fetched by scripts/fetch-spice-kernels.sh (~1.3 GB of ESA data)
+/spice/
+
 # test run artifacts
 /Aardvark.log
 /logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ PRo3D is built on top of the [Aardvark Platform](https://github.com/aardvark-pla
 | `adapt.cmd` / `adapt.sh` | Run Adaptify code generation for all projects (regenerates `*.g.fs`) |
 | `dotnet run --project src/PRo3D.Viewer` | Run the main viewer directly |
 | `dotnet fantomas src/` | Format F# source |
+| `runTests.cmd` / `runTests.sh` | Run the tests without SPICE kernels (`--skip-hera`) |
+| `runAllTests.cmd` / `runAllTests.sh` | Run everything, including the HERA kernel tests |
+| `scripts/fetch-spice-kernels.sh [dest]` | Download the HERA kernels those tests need, then set `PRO3D_SPICE_KERNELS` — see [docs/tests/SpiceKernels.md](docs/tests/SpiceKernels.md) |
 
 ## Technology Stack
 

--- a/docs/spice.md
+++ b/docs/spice.md
@@ -25,6 +25,9 @@ The components are:
  Caveats:
   - A legacy library for working with instruments is still handled directly via pro3d (JR.Wrappers provides the wrapper). This can be subsumed by SPICE the functionality is ready.
 
+ See also:
+  - [tests/SpiceKernels.md](tests/SpiceKernels.md) — getting ESA's HERA mission kernels for the test suite and for CI (`PRO3D_SPICE_KERNELS`). Those are the mission data files, distinct from the small default kernel set PRo3D itself ships and unpacks at startup.
+
 
 ## Details
 

--- a/docs/tests/SpiceKernels.md
+++ b/docs/tests/SpiceKernels.md
@@ -1,20 +1,17 @@
 # SPICE kernels for the test suite
 
-Part of the test suite drives real SPICE geometry: HERA spacecraft states, instrument
-frames, the Didymos-system body frames the mbi fixtures in `src/Tests/data` were
-generated against. That needs ESA's HERA mission kernels, which are public but far too
-large to commit or to carry in a submodule.
-
-[`scripts/fetch-spice-kernels.sh`](../../scripts/fetch-spice-kernels.sh) downloads
-exactly the kernels the suite loads — **~120 files, ~1.3 GB** — and CI caches them.
+Part of the suite drives real SPICE geometry — HERA spacecraft states, instrument frames,
+the Didymos-system frames the mbi fixtures in `src/Tests/data` were generated against.
+That needs ESA's HERA mission kernels: public, but too large to commit.
 
 | | |
 |---|---|
 | Source | `https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/` (public, no credentials) |
 | Full dataset | ~11 GB — do **not** mirror it |
-| What the suite needs | ~1.3 GB, the closure of four meta-kernels |
+| What the suite needs | 119 files, 1.23 GiB — the closure of four meta-kernels |
+| Fetched by | [`scripts/fetch-spice-kernels.sh`](../../scripts/fetch-spice-kernels.sh) |
 | Pinned in | [`scripts/spice-kernels.pins`](../../scripts/spice-kernels.pins) |
-| Read by | `HeraSpiceTests.kernelsDir`, via `$PRO3D_SPICE_KERNELS` |
+| Found via | `$PRO3D_SPICE_KERNELS`, read by `HeraSpiceTests.kernelsDir` |
 
 ## Getting them
 
@@ -23,36 +20,32 @@ scripts/fetch-spice-kernels.sh spice        # or scripts\fetch-spice-kernels.cmd
 PRO3D_SPICE_KERNELS=$PWD/spice ./runAllTests.sh
 ```
 
-`PRO3D_SPICE_KERNELS` is the same variable [`pro3d-tool`](../Pro3DTool.md) reads, and it
-is equally tolerant: point it at the dataset root (the directory holding `kernels/`) or
-straight at `kernels/`. Without the variable the tests fall back to a `spice` directory
-next to the PRo3D clone, which is how the developer workstations are laid out — a full
-ESA mirror there keeps working untouched.
+`PRO3D_SPICE_KERNELS` is the variable [`pro3d-tool`](../Pro3DTool.md) reads, and equally
+tolerant: the dataset root or `kernels/` itself. Without it the tests fall back to a
+`spice` directory next to the PRo3D clone, so an existing full mirror keeps working.
 
-Without kernels at either place, the kernel-backed tests skip themselves.
-`runTests.sh` / `runTests.cmd` pass `--skip-hera` to force that even on a machine that
-has them, so the kernel-free subset is deterministic; `runAllTests.sh` / `.cmd` run
+With kernels at neither place the kernel-backed tests skip. `runTests.sh` / `.cmd` pass
+`--skip-hera` to force that even where they are present; `runAllTests.sh` / `.cmd` run
 everything.
 
-## Why a fetch script and not a clone
+## Fetching, not cloning
 
-ESA also publishes the dataset as a git repository (`https://spiftp.esac.esa.int/git/hera.git`),
-and a working tree of it is ~11 GB — every version of every CK, SPK and DSK ever
-released. The tests need one percent of that, and a meta-kernel already names precisely
-which files SPICE will load, in its `KERNELS_TO_LOAD` block. So the script reads the
-pinned meta-kernels and fetches their closure over plain HTTPS: 119 files today, 1.23 GiB,
-resumable (the server honours range requests) and downloaded 8 at a time.
+ESA publishes the dataset as a git repo too (`https://spiftp.esac.esa.int/git/hera.git`),
+whose working tree is ~11 GB: every version of every CK, SPK and DSK ever released. The
+tests need one percent of it, and a meta-kernel's `KERNELS_TO_LOAD` already names exactly
+which files SPICE will open. So the script reads the pinned meta-kernels and fetches
+their closure over HTTPS — resumable (the server honours range requests), 8 at a time,
+about 90 s on a CI runner.
 
-## Why the pins, and how to bump them
+## The pins
 
 The tests open `hera_ops.tm` and `hera_plan.tm`. On the server those unversioned names
-are *copies of whatever release is newest*, and ESA publishes a new SKD every few weeks
-— at which point the previous versioned file moves from `mk/` into `mk/former_versions/`.
-Depending on those names directly would mean a CI run testing against kernels nobody
-chose, changing under you on ESA's schedule.
+are copies of whatever release is newest, and ESA ships a new SKD every few weeks, moving
+the superseded file from `mk/` into `mk/former_versions/`. Depending on them directly
+means testing against kernels nobody chose, changing on ESA's schedule.
 
-So `spice-kernels.pins` names versioned files, and the script writes the aliased ones
-into `mk/` under the plain names the tests expect:
+So the pins name versioned files, and the script writes the aliased ones into `mk/` under
+the plain names:
 
 ```
 hera_ops_v182_20260527_001.tm -> hera_ops.tm
@@ -61,91 +54,84 @@ hera_ops_v172_20250312_001.tm
 hera_plan_v180_20250616_001.tm
 ```
 
-The last two are not a choice: the mbi sidecars name them. An `.mbi.json` carries a
-`SPICE_MK` field naming the exact meta-kernel its geometry was produced against, and
-`HeraSpiceTests.loadKernelForMbiContent` honours it — comparing a projection against a
-fixture only means something under the kernels that fixture came from. They change when
-the fixtures are regenerated, not otherwise.
+The last two are not a choice. An `.mbi.json` sidecar's `SPICE_MK` field names the exact
+meta-kernel its geometry was produced against, and `HeraSpiceTests.loadKernelForMbiContent`
+honours it — checking a projection against a fixture only means anything under the kernels
+that fixture came from. They change when the fixtures are regenerated.
 
-Pins are looked up in `mk/` first and `mk/former_versions/` second, so a pin keeps
-working across the release that archives it. Archiving rewrites one line — `PATH_VALUES`
-goes from `'..'` to `'../..'`, because the file moved one directory deeper — and the
-script rewrites it back when it copies an archived meta-kernel into `mk/` under its
-plain name. The kernel list itself is untouched by archiving.
+Each pin is looked up in `mk/` first, `mk/former_versions/` second, so it survives the
+release that archives it. Archiving rewrites exactly one line — `PATH_VALUES` from `'..'`
+to `'../..'`, the file having moved a directory deeper — which the script puts back when
+it copies an archived meta-kernel into `mk/` under its plain name.
 
-**To bump:** change the version in `spice-kernels.pins`, run the script, run
+**To bump:** edit the version in `spice-kernels.pins`, run the script, run
 `runAllTests.sh`. Expect numeric differences in the projection tests if the new release
-revised a CK or SPK — that is the point of pinning, and reviewing the delta is the work.
-CI refetches automatically: the pins file is the cache key.
+revised a CK or SPK; reviewing that delta is the point. CI refetches on its own — the
+pins file is the cache key.
+
+## Loading a kernel
+
+Go through `PRo3D.Base.CooTransformation.switchKernel`, under
+`InstrumentProjection.withSpiceLock`. Two rules, both learned the hard way:
+
+**Never depend on the working directory.** SPICE stores the file names a meta-kernel
+produces as they read at furnsh time, and DAF re-opens binary kernels lazily, by the
+stored name, long after the load. ESA's meta-kernels name them relatively, so those names
+resolve only while the process still sits where it sat at load time. `switchKernel` calls
+`materializeMetaKernel`, which rewrites `PATH_VALUES` to the absolute directory it always
+meant. Nothing needs to `chdir` — and nothing may, since a process-global directory
+cannot be saved and restored around a call that races with other loads.
+
+**Hold the projection lock.** Switching is `DeInit` + `Init` + furnsh: it empties the
+kernel pool. Doing that while another thread is inside a SPICE call answers that call from
+two kernel sets, or crashes it.
+
+Get either wrong and the symptom lands nowhere near the cause: a failed lazy re-open, then
+`SPICE(BADSUBSCRIPT)` in `dafah` on the next `DeInit`, then every lookup returning
+`SPICE(DAFNOSUCHHANDLE)` — which reads exactly like a kernel with no coverage at the epoch
+you asked for.
+
+Only one meta-kernel is loaded at a time; there is no per-kernel unload, and layering them
+corrupts state (see `plans/archive/spiceKernelUnloadAndDidymosProjection.md`). Anything
+needing two has to serialise, and anything running work concurrently has to stay on one.
 
 ## What CI does
 
-`.github/workflows/build.yml` runs the kernel-free suite across the four-OS matrix and
+`.github/workflows/build.yml` runs the kernel-free suite across the four-OS matrix, and
 the kernel-backed suite in a separate `spice-tests` job:
 
-1. `actions/cache` on `spice/`, keyed by `hashFiles('scripts/spice-kernels.pins')`.
-   A new ESA release does not invalidate it; a pin bump does. `restore-keys` hands a
-   bumped run the previous tree so it refetches one closure rather than four.
-2. `bash scripts/fetch-spice-kernels.sh spice` — unconditionally, cache hit or not.
+1. `actions/cache` on `spice/`, keyed by `hashFiles('scripts/spice-kernels.pins')` — an
+   ESA release does not invalidate it, a pin bump does. `restore-keys` hands a bumped run
+   the previous tree, so it refetches one closure instead of four.
+2. `bash scripts/fetch-spice-kernels.sh spice`, cache hit or not.
 3. `PRO3D_SPICE_KERNELS=$GITHUB_WORKSPACE/spice bash ./runAllTests.sh`.
 
-Linux only, deliberately: kernels are platform-independent data, and a 1.3 GB cache
-entry per OS would push the paket caches out of the repository's 10 GB budget. What is
-covered on Linux is coverage of *this* data — the platform-specific risk lives in the
-kernel-free suite, which still runs everywhere.
+Linux only: kernels are platform-independent data, and a 1.3 GB cache entry per OS would
+push the paket caches out of the repository's 10 GB budget. The platform-specific risk
+sits in the kernel-free suite, which still runs everywhere.
 
-Step 2 runs on a cache hit as well, because the cheapest way to know a restored tree is
-usable is to ask the script: it verifies the tree against the manifest it wrote
-(`kernels/.pro3d-kernels-manifest` — one `path<TAB>size` line per file, plus the pins
-checksum it was written for) entirely offline, and exits in about a second when
-everything matches. When something does not match — a partial restore, or a bumped pin —
-it fetches only what is missing or short. A half-restored cache repairs itself rather
-than surfacing later as a puzzling `SPICE(FILEOPENFAIL)` deep inside CSPICE.
+Step 2 runs on a hit because asking the script is the cheapest way to know a restored tree
+is usable. It verifies the tree offline against the manifest it wrote
+(`kernels/.pro3d-kernels-manifest`: one `path<TAB>size` per file, plus the pins checksum
+it was written for) and exits in about a second; anything missing or short is refetched.
+A half-restored cache repairs itself instead of surfacing later as a puzzling
+`SPICE(FILEOPENFAIL)` inside CSPICE.
 
-One consequence worth knowing: the script never deletes anything, because `dest` may be
-a developer's own mirror. A CI tree carried across pin bumps therefore accumulates
-superseded kernels. That is bounded and cheap — a few hundred MB per bump, and cache
-entries expire after a week unused — but if the entry ever gets uncomfortably large,
-delete it from the Actions cache and let the next run refetch.
-
-## Loading a kernel, in tests or anywhere else
-
-Go through `PRo3D.Base.CooTransformation.switchKernel`. Two things it gets right that
-a direct `AddSpiceKernel` does not:
-
-- **Never depend on the working directory.** SPICE stores the file names a meta-kernel
-  produces exactly as they read at furnsh time, and DAF re-opens binary kernels lazily,
-  by the stored name, long after the load. ESA's meta-kernels name them relatively
-  (`PATH_VALUES` is `'..'` in `mk/`, `'../..'` in `mk/former_versions/`), so those names
-  only resolve while the process sits where it sat at load time. `switchKernel` calls
-  `materializeMetaKernel`, which rewrites `PATH_VALUES` to the absolute directory it
-  always meant. Nothing has to `chdir`, and nothing may — a process-global directory
-  cannot be saved and restored around a call that races with other loads.
-- **Take `InstrumentProjection.withSpiceLock` around it.** Switching is `DeInit` +
-  `Init` + furnsh: it empties the kernel pool. Doing that while another thread is inside
-  a SPICE call answers that call from two different kernel sets at best, and takes the
-  process down at worst.
-
-Get either wrong and the symptom appears nowhere near the cause: a failed lazy re-open,
-`SPICE(BADSUBSCRIPT)` in `dafah` on the next `DeInit`, and from then on every lookup
-returning `SPICE(DAFNOSUCHHANDLE)` — which reads exactly like a kernel that has no
-coverage at the epoch you asked for.
-
-Only one meta-kernel is loaded at a time (there is no per-kernel unload, and layering
-meta-kernels corrupts state — see `plans/archive/spiceKernelUnloadAndDidymosProjection.md`).
-Anything wanting two of them has to serialise, and anything running work *concurrently*
-has to stay on one.
+The script never deletes, since `dest` may be a developer's own mirror — so a CI tree
+carried across pin bumps accumulates superseded kernels. Bounded and cheap (cache entries
+expire after a week unused), but if an entry gets uncomfortably large, delete it and let
+the next run refetch.
 
 ## Notes
 
 - `spice/` is gitignored.
-- Kernels are ESA public data; nothing here needs credentials or a token.
-- The one thing the parser cannot handle is a meta-kernel that wraps a long path across
-  two quoted strings. None of the HERA meta-kernels do, and the script counts quoted
-  entries against parsed paths and fails loudly rather than quietly fetching a subset.
+- No credentials or tokens anywhere: this is ESA public data.
+- The parser cannot join a path wrapped across two quoted strings. No HERA meta-kernel
+  does that, and the script counts quoted entries against parsed paths so it would fail
+  loudly rather than fetch a subset.
 
 ## Related
 
 - [`docs/spice.md`](../spice.md) — how SPICE is wired into PRo3D at runtime
-- [`docs/tests/TestData.md`](TestData.md) — the OPC fixtures and where the other test data lives
+- [`docs/tests/TestData.md`](TestData.md) — the OPC fixtures and the other test data
 - [`docs/Pro3DTool.md`](../Pro3DTool.md) — `PRO3D_SPICE_KERNELS` for the command-line tool

--- a/docs/tests/SpiceKernels.md
+++ b/docs/tests/SpiceKernels.md
@@ -1,0 +1,123 @@
+# SPICE kernels for the test suite
+
+Part of the test suite drives real SPICE geometry: HERA spacecraft states, instrument
+frames, the Didymos-system body frames the mbi fixtures in `src/Tests/data` were
+generated against. That needs ESA's HERA mission kernels, which are public but far too
+large to commit or to carry in a submodule.
+
+[`scripts/fetch-spice-kernels.sh`](../../scripts/fetch-spice-kernels.sh) downloads
+exactly the kernels the suite loads — **~120 files, ~1.3 GB** — and CI caches them.
+
+| | |
+|---|---|
+| Source | `https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/` (public, no credentials) |
+| Full dataset | ~11 GB — do **not** mirror it |
+| What the suite needs | ~1.3 GB, the closure of four meta-kernels |
+| Pinned in | [`scripts/spice-kernels.pins`](../../scripts/spice-kernels.pins) |
+| Read by | `HeraSpiceTests.kernelsDir`, via `$PRO3D_SPICE_KERNELS` |
+
+## Getting them
+
+```bash
+scripts/fetch-spice-kernels.sh spice        # or scripts\fetch-spice-kernels.cmd
+PRO3D_SPICE_KERNELS=$PWD/spice ./runAllTests.sh
+```
+
+`PRO3D_SPICE_KERNELS` is the same variable [`pro3d-tool`](../Pro3DTool.md) reads, and it
+is equally tolerant: point it at the dataset root (the directory holding `kernels/`) or
+straight at `kernels/`. Without the variable the tests fall back to a `spice` directory
+next to the PRo3D clone, which is how the developer workstations are laid out — a full
+ESA mirror there keeps working untouched.
+
+Without kernels at either place, the kernel-backed tests skip themselves.
+`runTests.sh` / `runTests.cmd` pass `--skip-hera` to force that even on a machine that
+has them, so the kernel-free subset is deterministic; `runAllTests.sh` / `.cmd` run
+everything.
+
+## Why a fetch script and not a clone
+
+ESA also publishes the dataset as a git repository (`https://spiftp.esac.esa.int/git/hera.git`),
+and a working tree of it is ~11 GB — every version of every CK, SPK and DSK ever
+released. The tests need one percent of that, and a meta-kernel already names precisely
+which files SPICE will load, in its `KERNELS_TO_LOAD` block. So the script reads the
+pinned meta-kernels and fetches their closure over plain HTTPS: 119 files today, 1.23 GiB,
+resumable (the server honours range requests) and downloaded 8 at a time.
+
+## Why the pins, and how to bump them
+
+The tests open `hera_ops.tm` and `hera_plan.tm`. On the server those unversioned names
+are *copies of whatever release is newest*, and ESA publishes a new SKD every few weeks
+— at which point the previous versioned file moves from `mk/` into `mk/former_versions/`.
+Depending on those names directly would mean a CI run testing against kernels nobody
+chose, changing under you on ESA's schedule.
+
+So `spice-kernels.pins` names versioned files, and the script writes the aliased ones
+into `mk/` under the plain names the tests expect:
+
+```
+hera_ops_v182_20260527_001.tm -> hera_ops.tm
+hera_plan_v182_20260527_001.tm -> hera_plan.tm
+hera_ops_v172_20250312_001.tm
+hera_plan_v180_20250616_001.tm
+```
+
+The last two are not a choice: the mbi sidecars name them. An `.mbi.json` carries a
+`SPICE_MK` field naming the exact meta-kernel its geometry was produced against, and
+`HeraSpiceTests.loadKernelForMbiContent` honours it — comparing a projection against a
+fixture only means something under the kernels that fixture came from. They change when
+the fixtures are regenerated, not otherwise.
+
+Pins are looked up in `mk/` first and `mk/former_versions/` second, so a pin keeps
+working across the release that archives it. Archiving rewrites one line — `PATH_VALUES`
+goes from `'..'` to `'../..'`, because the file moved one directory deeper — and the
+script rewrites it back when it copies an archived meta-kernel into `mk/` under its
+plain name. The kernel list itself is untouched by archiving.
+
+**To bump:** change the version in `spice-kernels.pins`, run the script, run
+`runAllTests.sh`. Expect numeric differences in the projection tests if the new release
+revised a CK or SPK — that is the point of pinning, and reviewing the delta is the work.
+CI refetches automatically: the pins file is the cache key.
+
+## What CI does
+
+`.github/workflows/build.yml` runs the kernel-free suite across the four-OS matrix and
+the kernel-backed suite in a separate `spice-tests` job:
+
+1. `actions/cache` on `spice/`, keyed by `hashFiles('scripts/spice-kernels.pins')`.
+   A new ESA release does not invalidate it; a pin bump does. `restore-keys` hands a
+   bumped run the previous tree so it refetches one closure rather than four.
+2. `bash scripts/fetch-spice-kernels.sh spice` — unconditionally, cache hit or not.
+3. `PRO3D_SPICE_KERNELS=$GITHUB_WORKSPACE/spice bash ./runAllTests.sh`.
+
+Linux only, deliberately: kernels are platform-independent data, and a 1.3 GB cache
+entry per OS would push the paket caches out of the repository's 10 GB budget. What is
+covered on Linux is coverage of *this* data — the platform-specific risk lives in the
+kernel-free suite, which still runs everywhere.
+
+Step 2 runs on a cache hit as well, because the cheapest way to know a restored tree is
+usable is to ask the script: it verifies the tree against the manifest it wrote
+(`kernels/.pro3d-kernels-manifest` — one `path<TAB>size` line per file, plus the pins
+checksum it was written for) entirely offline, and exits in about a second when
+everything matches. When something does not match — a partial restore, or a bumped pin —
+it fetches only what is missing or short. A half-restored cache repairs itself rather
+than surfacing later as a puzzling `SPICE(FILEOPENFAIL)` deep inside CSPICE.
+
+One consequence worth knowing: the script never deletes anything, because `dest` may be
+a developer's own mirror. A CI tree carried across pin bumps therefore accumulates
+superseded kernels. That is bounded and cheap — a few hundred MB per bump, and cache
+entries expire after a week unused — but if the entry ever gets uncomfortably large,
+delete it from the Actions cache and let the next run refetch.
+
+## Notes
+
+- `spice/` is gitignored.
+- Kernels are ESA public data; nothing here needs credentials or a token.
+- The one thing the parser cannot handle is a meta-kernel that wraps a long path across
+  two quoted strings. None of the HERA meta-kernels do, and the script counts quoted
+  entries against parsed paths and fails loudly rather than quietly fetching a subset.
+
+## Related
+
+- [`docs/spice.md`](../spice.md) — how SPICE is wired into PRo3D at runtime
+- [`docs/tests/TestData.md`](TestData.md) — the OPC fixtures and where the other test data lives
+- [`docs/Pro3DTool.md`](../Pro3DTool.md) — `PRO3D_SPICE_KERNELS` for the command-line tool

--- a/docs/tests/SpiceKernels.md
+++ b/docs/tests/SpiceKernels.md
@@ -108,6 +108,34 @@ superseded kernels. That is bounded and cheap — a few hundred MB per bump, and
 entries expire after a week unused — but if the entry ever gets uncomfortably large,
 delete it from the Actions cache and let the next run refetch.
 
+## Loading a kernel, in tests or anywhere else
+
+Go through `PRo3D.Base.CooTransformation.switchKernel`. Two things it gets right that
+a direct `AddSpiceKernel` does not:
+
+- **Never depend on the working directory.** SPICE stores the file names a meta-kernel
+  produces exactly as they read at furnsh time, and DAF re-opens binary kernels lazily,
+  by the stored name, long after the load. ESA's meta-kernels name them relatively
+  (`PATH_VALUES` is `'..'` in `mk/`, `'../..'` in `mk/former_versions/`), so those names
+  only resolve while the process sits where it sat at load time. `switchKernel` calls
+  `materializeMetaKernel`, which rewrites `PATH_VALUES` to the absolute directory it
+  always meant. Nothing has to `chdir`, and nothing may — a process-global directory
+  cannot be saved and restored around a call that races with other loads.
+- **Take `InstrumentProjection.withSpiceLock` around it.** Switching is `DeInit` +
+  `Init` + furnsh: it empties the kernel pool. Doing that while another thread is inside
+  a SPICE call answers that call from two different kernel sets at best, and takes the
+  process down at worst.
+
+Get either wrong and the symptom appears nowhere near the cause: a failed lazy re-open,
+`SPICE(BADSUBSCRIPT)` in `dafah` on the next `DeInit`, and from then on every lookup
+returning `SPICE(DAFNOSUCHHANDLE)` — which reads exactly like a kernel that has no
+coverage at the epoch you asked for.
+
+Only one meta-kernel is loaded at a time (there is no per-kernel unload, and layering
+meta-kernels corrupts state — see `plans/archive/spiceKernelUnloadAndDidymosProjection.md`).
+Anything wanting two of them has to serialise, and anything running work *concurrently*
+has to stay on one.
+
 ## Notes
 
 - `spice/` is gitignored.

--- a/docs/tests/TestData.md
+++ b/docs/tests/TestData.md
@@ -70,7 +70,9 @@ Weigh every megabyte: anyone who initialises the submodule downloads all of it.
 
 - `src/Tests/data/` holds the small, text-based fixtures that are checked into PRo3D
   directly (instrument metadata sidecars, annotation files). These need no submodule.
-- The SPICE tests need the non-public HERA kernels and self-skip without them;
-  `runTests.cmd` / `runTests.sh` pass `--skip-hera` so they skip deterministically.
+- The SPICE tests need ESA's HERA mission kernels — public, but ~1.3 GB, so they are
+  fetched rather than committed. See [SpiceKernels.md](SpiceKernels.md). They self-skip
+  without them; `runTests.cmd` / `runTests.sh` pass `--skip-hera` so they skip
+  deterministically even where the kernels are present.
 - `ProfileAttributeExtractionTest` takes its data from `--testdatasource <path>` instead,
   and is only added to the run when that argument is given.

--- a/runAllTests.cmd
+++ b/runAllTests.cmd
@@ -1,6 +1,9 @@
 @echo off
-REM Runs ALL tests, including the HERA SPICE-kernel tests. These require the
-REM (non-public) HERA kernels under spice\kernels (e.g. spice\kernels\mk\hera_ops.tm);
-REM without them the heraSpice tests will fail. For the kernel-independent subset
+REM Runs ALL tests, including the HERA SPICE-kernel tests. Those need ESA's HERA
+REM mission kernels; without them they skip themselves. Get them with
+REM   scripts\fetch-spice-kernels.cmd spice
+REM   set PRO3D_SPICE_KERNELS=%CD%\spice
+REM (or leave a full mirror in a 'spice' directory next to the PRo3D clone, which is
+REM the fallback). See docs\tests\SpiceKernels.md. For the kernel-independent subset
 REM use runTests.cmd instead. Extra args are passed through to the Expecto runner.
 dotnet run --project src/Tests/Tests.fsproj -c Release -- %*

--- a/runAllTests.sh
+++ b/runAllTests.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Runs ALL tests, including the HERA SPICE-kernel tests. These require the
-# (non-public) HERA kernels under spice/kernels (e.g. spice/kernels/mk/hera_ops.tm);
-# without them the heraSpice tests will fail. For the kernel-independent subset
-# use runTests.sh instead. Extra args are passed through to the Expecto runner.
+# Runs ALL tests, including the HERA SPICE-kernel tests. Those need ESA's HERA mission
+# kernels; without them they skip themselves. Get them with
+#   scripts/fetch-spice-kernels.sh spice
+#   export PRO3D_SPICE_KERNELS=$PWD/spice
+# (or leave a full mirror in a 'spice' directory next to the PRo3D clone, which is the
+# fallback). See docs/tests/SpiceKernels.md. For the kernel-independent subset use
+# runTests.sh instead. Extra args are passed through to the Expecto runner.
 set -e
 dotnet run --project src/Tests/Tests.fsproj -c Release -- "$@"

--- a/scripts/fetch-spice-kernels.cmd
+++ b/scripts/fetch-spice-kernels.cmd
@@ -1,0 +1,11 @@
+@echo off
+REM Downloads the HERA SPICE kernels the test suite needs (see spice-kernels.pins).
+REM
+REM   fetch-spice-kernels.cmd [dest]        default dest: .\spice
+REM
+REM Then point the tests at it:  set PRO3D_SPICE_KERNELS=<dest>
+REM
+REM Needs bash and curl -- both ship with Git for Windows. The work is in the .sh; this
+REM is only here so the script is reachable the same way as its siblings.
+
+bash "%~dp0fetch-spice-kernels.sh" %*

--- a/scripts/fetch-spice-kernels.sh
+++ b/scripts/fetch-spice-kernels.sh
@@ -1,23 +1,16 @@
 #!/usr/bin/env bash
-# Downloads exactly the HERA SPICE kernels the test suite needs into <dest>/kernels,
-# laid out like the ESA server so the meta-kernels' relative $KERNELS paths resolve.
+# Downloads the HERA SPICE kernels the test suite needs into <dest>/kernels, laid out
+# like the ESA server. See docs/tests/SpiceKernels.md.
 #
 #   scripts/fetch-spice-kernels.sh [dest]        # default dest: ./spice
 #   PRO3D_SPICE_KERNELS=<dest> ./runAllTests.sh  # then point the tests at it
 #
-# What it fetches is the transitive closure of the meta-kernels pinned in
-# scripts/spice-kernels.pins -- ~120 files, ~1.3 GB. The full ESA dataset is ~11 GB
-# and its git repo carries every version ever published, so neither is worth cloning
-# for a test run; the meta-kernels already name precisely what SPICE will load.
+# Fetches the closure of the meta-kernels pinned in scripts/spice-kernels.pins: ~120
+# files, ~1.3 GB, out of an ~11 GB dataset. Re-running is offline and takes a second
+# when the tree is complete, so it is safe to run unconditionally after a CI cache
+# restore; a partial restore heals instead of failing later inside CSPICE.
 #
-# Re-running is cheap and offline: a completed tree records a manifest, and a rerun
-# only re-reads that plus local file sizes. Only a missing/short/absent file costs a
-# request, which is what makes this safe to run unconditionally after a CI cache
-# restore -- a half-populated cache heals itself instead of failing the run later
-# inside CSPICE.
-#
-# Env: PRO3D_SPICE_BASE_URL (mirror to fetch from), PRO3D_SPICE_JOBS (parallel
-# downloads, default 8).
+# Env: PRO3D_SPICE_BASE_URL (mirror), PRO3D_SPICE_JOBS (parallel downloads, default 8).
 set -euo pipefail
 
 BASE_URL="${PRO3D_SPICE_BASE_URL:-https://spiftp.esac.esa.int/data/SPICE/HERA/kernels}"
@@ -28,9 +21,8 @@ pins_file="$script_dir/spice-kernels.pins"
 
 file_size() { wc -c < "$1" | tr -d ' '; }
 
-# --retry-all-errors (curl 7.71+) is what makes a retry cover a mid-transfer reset,
-# not just a connection failure. Older curl rejects the unknown option outright, so
-# ask before using it rather than failing every download on an old runner image.
+# --retry-all-errors (curl 7.71+) covers a mid-transfer reset, not just a failed
+# connection. Older curl rejects unknown options outright, so ask before passing it.
 retry_opts() {
     local opts="--retry 5 --retry-delay 2 --retry-connrefused --speed-limit 1024 --speed-time 60"
     if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
@@ -39,13 +31,11 @@ retry_opts() {
     echo "$opts"
 }
 
-# Once per process: each worker re-enters this script, so this costs one probe per
-# download, not one per curl call.
+# Once per process -- workers re-enter this script, so it is one probe per download.
 RETRY_OPTS="$(retry_opts)"
 
-# Size the remote file so a rerun can tell "already have it" from "have half of it".
-# Empty output means "unknown" -- a server that refuses HEAD is a reason to download
-# and skip the size check, never a reason to fail the run, hence the `|| true`.
+# Remote size, so a rerun can tell "already have it" from "have half of it". Empty
+# means unknown: a server refusing HEAD means download anyway, not fail (`|| true`).
 remote_size() {
     local headers
     headers="$(curl -fsSIL --max-time 60 $RETRY_OPTS "$1" 2>/dev/null || true)"
@@ -55,8 +45,7 @@ remote_size() {
 }
 
 # One download, in its own process so xargs can run several. Re-entering the script
-# this way (rather than exporting a function) keeps it working under any /bin/sh-ish
-# xargs and on Git Bash.
+# beats exporting a function: it works under any xargs, Git Bash included.
 fetch_one() {
     local kernels_dir="$1" rel="$2"
     local out="$kernels_dir/$rel" url="$BASE_URL/$rel"
@@ -97,9 +86,8 @@ kernels_dir="$dest/kernels"
 manifest="$kernels_dir/.pro3d-kernels-manifest"
 
 # Every quoted entry in KERNELS_TO_LOAD, as a path below kernels/. The count check
-# guards the one way this parse can silently under-deliver: a meta-kernel that wraps
-# a long path across two quoted strings would yield fewer paths than quoted lines,
-# and the missing kernel would only surface much later as a puzzling SPICE error.
+# catches the one way this can under-deliver: a path wrapped across two quoted strings
+# parses as fewer paths than quoted lines, and the kernel goes missing without a word.
 kernel_list() {
     local mk="$1"
     local paths quoted
@@ -113,11 +101,9 @@ kernel_list() {
     printf '%s\n' "$paths"
 }
 
-# Where a pinned meta-kernel lives below kernels/. ESA keeps the newest release in
-# mk/ and moves it to mk/former_versions/ as soon as the next one is published, so a
-# pin that is current today is archived in a few weeks - look in both, newest first.
-# Local hits first so a half-populated tree costs no requests, and so the answer does
-# not change mid-life of a cache entry.
+# Where a pinned meta-kernel lives below kernels/. ESA moves the newest release from
+# mk/ to mk/former_versions/ as soon as the next one lands, so look in both. Local hits
+# first, so a half-populated tree costs no requests.
 resolve_mk() {
     local name="$1" candidate
     for candidate in "mk/$name" "mk/former_versions/$name"; do
@@ -142,14 +128,12 @@ pins_id="$(printf '%s\n' "$pins" | cksum | tr -d ' ')"
 
 echo "SPICE kernels -> $kernels_dir"
 
-# Fast path: this manifest was written for today's pins, and everything it promised is
-# still there at the right size. That is the CI-cache-hit case and must not touch the
-# network.
+# Fast path, and the CI cache hit: the manifest was written for today's pins and
+# everything it lists is still there at the right size. Must not touch the network.
 #
-# The pins check is what makes it safe to restore a cache entry written for older pins
-# (CI does, via restore-keys, so that bumping one pin refetches one closure instead of
-# all four): every file such a tree lists is present and correct, so a size-only check
-# would call it complete and never fetch the newly pinned meta-kernel.
+# The pins check is what makes restoring an older entry safe (CI does, via restore-keys,
+# so a pin bump refetches one closure rather than four): every file such a tree lists is
+# present and correct, so a size-only check would never fetch the new meta-kernel.
 if [ -f "$manifest" ] && [ "$(head -n 1 "$manifest")" = "#pins $pins_id" ]; then
     complete=1
     while IFS=$'\t' read -r rel size; do
@@ -168,11 +152,9 @@ elif [ -f "$manifest" ]; then
     echo "  manifest was written for different pins -- refetching what changed"
 fi
 
-# The meta-kernels first: they are what says which kernels exist.
-#
-# Aliased pins are additionally written into mk/ under their plain name (hera_ops.tm,
-# hera_plan.tm) - the names the tests open, and the names PRo3D ships with, while the
-# pin file decides which release they actually are.
+# The meta-kernels first: they are what says which kernels exist. Aliased pins are also
+# written into mk/ under the plain name the tests open (hera_ops.tm, hera_plan.tm),
+# while the pin file decides which release that actually is.
 mk_paths=()
 aliases=()
 while IFS= read -r line; do
@@ -183,12 +165,10 @@ while IFS= read -r line; do
     case "$line" in
         *" -> "*)
             alias_name="${line##* -> }"
-            # ESA rewrites PATH_VALUES from '..' to '../..' when it archives a
-            # meta-kernel into former_versions/ - the kernel list is untouched, only
-            # that one line differs. A copy landing back in mk/ therefore has to have
-            # it rewritten, or every $KERNELS path resolves one directory too high
-            # (the tests chdir to the meta-kernel's own directory before loading it).
-            # A no-op when the pin is still current and sits in mk/.
+            # Archiving into former_versions/ rewrites PATH_VALUES from '..' to
+            # '../..' and nothing else, so a copy landing back in mk/ has to have it
+            # put back, or every $KERNELS path resolves one directory too high. A no-op
+            # for a pin still sitting in mk/.
             sed "s|\(PATH_VALUES *= *( *\)'[^']*'|\1'..'|" "$kernels_dir/$mk_path" \
                 > "$kernels_dir/mk/$alias_name"
             aliases+=("mk/$alias_name")
@@ -196,13 +176,9 @@ while IFS= read -r line; do
     esac
 done <<< "$pins"
 
-# Union of the closures. Sorting is what deduplicates: the four meta-kernels overlap
-# heavily (~250 entries collapse to ~120 files), and downloading a 338 MB CK twice
-# would double the cold-cache cost for nothing.
-#
-# Accumulated in a file rather than a `$(... | sort)` pipeline on purpose: a failing
-# kernel_list inside a pipeline's subshell would be masked by sort's exit status, and
-# a truncated kernel list is precisely the failure that must not pass silently.
+# Union of the closures; sorting deduplicates the heavy overlap (~250 entries, ~120
+# files). Accumulated in a file rather than a sort pipeline because sort's exit status
+# would mask a failing kernel_list -- the one failure that must not pass silently.
 closure_file="$kernels_dir/.pro3d-kernels-closure"
 : > "$closure_file"
 for mk in "${mk_paths[@]}"; do
@@ -214,8 +190,8 @@ echo "  $(grep -c . "$closure_file") kernels named by ${#mk_paths[@]} meta-kerne
 xargs -P "$JOBS" -I {} "$script_dir/fetch-spice-kernels.sh" --fetch-one "$kernels_dir" {} \
     < "$closure_file"
 
-# Write the manifest last, and only from files that are actually on disk -- it is the
-# "this tree is usable" marker, so a partial write here would be worse than none.
+# The manifest last, and only from files actually on disk: it is the "tree is usable"
+# marker, so a partial one is worse than none.
 : > "$manifest.tmp"
 for rel in "${mk_paths[@]}" "${aliases[@]}" $(cat "$closure_file"); do
     if [ ! -f "$kernels_dir/$rel" ]; then
@@ -226,8 +202,7 @@ for rel in "${mk_paths[@]}" "${aliases[@]}" $(cat "$closure_file"); do
     printf '%s\t%s\n' "$rel" "$(file_size "$kernels_dir/$rel")" >> "$manifest.tmp"
 done
 sort -u "$manifest.tmp" -o "$manifest.tmp"
-# The pins line first, so the fast path can reject a manifest from other pins by
-# reading one line.
+# Pins line first, so the fast path can reject a foreign manifest in one read.
 { echo "#pins $pins_id"; cat "$manifest.tmp"; } > "$manifest.new"
 mv "$manifest.new" "$manifest"
 rm -f "$manifest.tmp"

--- a/scripts/fetch-spice-kernels.sh
+++ b/scripts/fetch-spice-kernels.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Downloads exactly the HERA SPICE kernels the test suite needs into <dest>/kernels,
+# laid out like the ESA server so the meta-kernels' relative $KERNELS paths resolve.
+#
+#   scripts/fetch-spice-kernels.sh [dest]        # default dest: ./spice
+#   PRO3D_SPICE_KERNELS=<dest> ./runAllTests.sh  # then point the tests at it
+#
+# What it fetches is the transitive closure of the meta-kernels pinned in
+# scripts/spice-kernels.pins -- ~120 files, ~1.3 GB. The full ESA dataset is ~11 GB
+# and its git repo carries every version ever published, so neither is worth cloning
+# for a test run; the meta-kernels already name precisely what SPICE will load.
+#
+# Re-running is cheap and offline: a completed tree records a manifest, and a rerun
+# only re-reads that plus local file sizes. Only a missing/short/absent file costs a
+# request, which is what makes this safe to run unconditionally after a CI cache
+# restore -- a half-populated cache heals itself instead of failing the run later
+# inside CSPICE.
+#
+# Env: PRO3D_SPICE_BASE_URL (mirror to fetch from), PRO3D_SPICE_JOBS (parallel
+# downloads, default 8).
+set -euo pipefail
+
+BASE_URL="${PRO3D_SPICE_BASE_URL:-https://spiftp.esac.esa.int/data/SPICE/HERA/kernels}"
+JOBS="${PRO3D_SPICE_JOBS:-8}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pins_file="$script_dir/spice-kernels.pins"
+
+file_size() { wc -c < "$1" | tr -d ' '; }
+
+# --retry-all-errors (curl 7.71+) is what makes a retry cover a mid-transfer reset,
+# not just a connection failure. Older curl rejects the unknown option outright, so
+# ask before using it rather than failing every download on an old runner image.
+retry_opts() {
+    local opts="--retry 5 --retry-delay 2 --retry-connrefused --speed-limit 1024 --speed-time 60"
+    if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+        opts="$opts --retry-all-errors"
+    fi
+    echo "$opts"
+}
+
+# Once per process: each worker re-enters this script, so this costs one probe per
+# download, not one per curl call.
+RETRY_OPTS="$(retry_opts)"
+
+# Size the remote file so a rerun can tell "already have it" from "have half of it".
+# Empty output means "unknown" -- a server that refuses HEAD is a reason to download
+# and skip the size check, never a reason to fail the run, hence the `|| true`.
+remote_size() {
+    local headers
+    headers="$(curl -fsSIL --max-time 60 $RETRY_OPTS "$1" 2>/dev/null || true)"
+    printf '%s\n' "$headers" \
+        | tr -d '\r' \
+        | awk 'BEGIN { IGNORECASE = 1 } /^content-length:/ { n = $2 } END { if (n != "") print n }'
+}
+
+# One download, in its own process so xargs can run several. Re-entering the script
+# this way (rather than exporting a function) keeps it working under any /bin/sh-ish
+# xargs and on Git Bash.
+fetch_one() {
+    local kernels_dir="$1" rel="$2"
+    local out="$kernels_dir/$rel" url="$BASE_URL/$rel"
+    mkdir -p "$(dirname "$out")"
+
+    local remote
+    remote="$(remote_size "$url")"
+
+    if [ -f "$out" ] && [ -n "$remote" ]; then
+        local have
+        have="$(file_size "$out")"
+        if [ "$have" = "$remote" ]; then
+            return 0
+        fi
+        # Resuming onto a file that is already longer than the remote one cannot
+        # produce the remote file -- it is corrupt, or the pin moved. Start over.
+        if [ "$have" -gt "$remote" ]; then
+            rm -f "$out"
+        fi
+    fi
+
+    echo "  fetching $rel"
+    curl -fsSL --max-time 3600 $RETRY_OPTS -C - -o "$out" "$url"
+
+    if [ -n "$remote" ] && [ "$(file_size "$out")" != "$remote" ]; then
+        echo "error: $rel is $(file_size "$out") bytes, server says $remote" >&2
+        return 1
+    fi
+}
+
+if [ "${1:-}" = "--fetch-one" ]; then
+    fetch_one "$2" "$3"
+    exit $?
+fi
+
+dest="${1:-./spice}"
+kernels_dir="$dest/kernels"
+manifest="$kernels_dir/.pro3d-kernels-manifest"
+
+# Every quoted entry in KERNELS_TO_LOAD, as a path below kernels/. The count check
+# guards the one way this parse can silently under-deliver: a meta-kernel that wraps
+# a long path across two quoted strings would yield fewer paths than quoted lines,
+# and the missing kernel would only surface much later as a puzzling SPICE error.
+kernel_list() {
+    local mk="$1"
+    local paths quoted
+    paths="$(tr -d '\r' < "$mk" | sed -n "s|.*\$KERNELS/\([^']*\)'.*|\1|p")"
+    quoted="$(tr -d '\r' < "$mk" | awk '/KERNELS_TO_LOAD/, /^ *\)/' | grep -c "'" || true)"
+    if [ "$(printf '%s\n' "$paths" | grep -c .)" != "$quoted" ]; then
+        echo "error: $mk lists $quoted kernels but $(printf '%s\n' "$paths" | grep -c .) parsed" >&2
+        echo "       (a wrapped path in KERNELS_TO_LOAD? this parser cannot join those)" >&2
+        return 1
+    fi
+    printf '%s\n' "$paths"
+}
+
+# Where a pinned meta-kernel lives below kernels/. ESA keeps the newest release in
+# mk/ and moves it to mk/former_versions/ as soon as the next one is published, so a
+# pin that is current today is archived in a few weeks - look in both, newest first.
+# Local hits first so a half-populated tree costs no requests, and so the answer does
+# not change mid-life of a cache entry.
+resolve_mk() {
+    local name="$1" candidate
+    for candidate in "mk/$name" "mk/former_versions/$name"; do
+        if [ -f "$kernels_dir/$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    for candidate in "mk/$name" "mk/former_versions/$name"; do
+        if curl -fsSIL --max-time 60 $RETRY_OPTS -o /dev/null "$BASE_URL/$candidate" 2>/dev/null; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    echo "error: meta-kernel $name is in neither mk/ nor mk/former_versions/ of $BASE_URL" >&2
+    return 1
+}
+
+# Pins, minus comments and blank lines: "<mk file name>[ -> <alias in mk/>]".
+pins="$(sed -e 's/#.*//' -e 's/[[:space:]]*$//' "$pins_file" | grep -v '^$')"
+pins_id="$(printf '%s\n' "$pins" | cksum | tr -d ' ')"
+
+echo "SPICE kernels -> $kernels_dir"
+
+# Fast path: this manifest was written for today's pins, and everything it promised is
+# still there at the right size. That is the CI-cache-hit case and must not touch the
+# network.
+#
+# The pins check is what makes it safe to restore a cache entry written for older pins
+# (CI does, via restore-keys, so that bumping one pin refetches one closure instead of
+# all four): every file such a tree lists is present and correct, so a size-only check
+# would call it complete and never fetch the newly pinned meta-kernel.
+if [ -f "$manifest" ] && [ "$(head -n 1 "$manifest")" = "#pins $pins_id" ]; then
+    complete=1
+    while IFS=$'\t' read -r rel size; do
+        case "${rel:-}" in "" | '#'*) continue ;; esac
+        if [ ! -f "$kernels_dir/$rel" ] || [ "$(file_size "$kernels_dir/$rel")" != "$size" ]; then
+            complete=0
+            break
+        fi
+    done < "$manifest"
+    if [ "$complete" = 1 ]; then
+        echo "  $(grep -cv '^#' "$manifest") kernels present and complete (manifest verified, no downloads)"
+        exit 0
+    fi
+    echo "  manifest incomplete -- refetching what is missing"
+elif [ -f "$manifest" ]; then
+    echo "  manifest was written for different pins -- refetching what changed"
+fi
+
+# The meta-kernels first: they are what says which kernels exist.
+#
+# Aliased pins are additionally written into mk/ under their plain name (hera_ops.tm,
+# hera_plan.tm) - the names the tests open, and the names PRo3D ships with, while the
+# pin file decides which release they actually are.
+mk_paths=()
+aliases=()
+while IFS= read -r line; do
+    mk_path="$(resolve_mk "${line%% -> *}")"
+    fetch_one "$kernels_dir" "$mk_path"
+    mk_paths+=("$mk_path")
+
+    case "$line" in
+        *" -> "*)
+            alias_name="${line##* -> }"
+            # ESA rewrites PATH_VALUES from '..' to '../..' when it archives a
+            # meta-kernel into former_versions/ - the kernel list is untouched, only
+            # that one line differs. A copy landing back in mk/ therefore has to have
+            # it rewritten, or every $KERNELS path resolves one directory too high
+            # (the tests chdir to the meta-kernel's own directory before loading it).
+            # A no-op when the pin is still current and sits in mk/.
+            sed "s|\(PATH_VALUES *= *( *\)'[^']*'|\1'..'|" "$kernels_dir/$mk_path" \
+                > "$kernels_dir/mk/$alias_name"
+            aliases+=("mk/$alias_name")
+            ;;
+    esac
+done <<< "$pins"
+
+# Union of the closures. Sorting is what deduplicates: the four meta-kernels overlap
+# heavily (~250 entries collapse to ~120 files), and downloading a 338 MB CK twice
+# would double the cold-cache cost for nothing.
+#
+# Accumulated in a file rather than a `$(... | sort)` pipeline on purpose: a failing
+# kernel_list inside a pipeline's subshell would be masked by sort's exit status, and
+# a truncated kernel list is precisely the failure that must not pass silently.
+closure_file="$kernels_dir/.pro3d-kernels-closure"
+: > "$closure_file"
+for mk in "${mk_paths[@]}"; do
+    kernel_list "$kernels_dir/$mk" >> "$closure_file"
+done
+sort -u -o "$closure_file" "$closure_file"
+echo "  $(grep -c . "$closure_file") kernels named by ${#mk_paths[@]} meta-kernels"
+
+xargs -P "$JOBS" -I {} "$script_dir/fetch-spice-kernels.sh" --fetch-one "$kernels_dir" {} \
+    < "$closure_file"
+
+# Write the manifest last, and only from files that are actually on disk -- it is the
+# "this tree is usable" marker, so a partial write here would be worse than none.
+: > "$manifest.tmp"
+for rel in "${mk_paths[@]}" "${aliases[@]}" $(cat "$closure_file"); do
+    if [ ! -f "$kernels_dir/$rel" ]; then
+        echo "error: $rel missing after fetch" >&2
+        rm -f "$manifest.tmp"
+        exit 1
+    fi
+    printf '%s\t%s\n' "$rel" "$(file_size "$kernels_dir/$rel")" >> "$manifest.tmp"
+done
+sort -u "$manifest.tmp" -o "$manifest.tmp"
+# The pins line first, so the fast path can reject a manifest from other pins by
+# reading one line.
+{ echo "#pins $pins_id"; cat "$manifest.tmp"; } > "$manifest.new"
+mv "$manifest.new" "$manifest"
+rm -f "$manifest.tmp"
+
+total="$(awk -F'\t' '$1 !~ /^#/ { n += $2 } END { printf "%.1f", n / 1073741824 }' "$manifest")"
+echo "  done: $(grep -cv '^#' "$manifest") files, ${total} GiB"
+echo "  point the tests at it with PRO3D_SPICE_KERNELS=$(cd "$dest" && pwd)"

--- a/scripts/spice-kernels.pins
+++ b/scripts/spice-kernels.pins
@@ -1,0 +1,32 @@
+# HERA SPICE meta-kernels the test suite loads, pinned to exact ESA SKD releases.
+#
+# scripts/fetch-spice-kernels.sh downloads each meta-kernel listed here plus every
+# kernel it names in KERNELS_TO_LOAD - nothing else. That closure is ~1.3 GB across
+# ~120 files; the full ESA dataset is ~11 GB, so do not be tempted to mirror the tree.
+#
+# Format, one entry per line:
+#   <versioned meta-kernel file name>[ -> <name to also write into mk/>]
+#
+# Only the file name: ESA keeps the newest release in kernels/mk/ and moves it to
+# kernels/mk/former_versions/ the moment the next one is published (which happens
+# every few weeks), so the fetch script looks in both. A pin that named a directory
+# would break on ESA's release schedule rather than on ours.
+#
+# The alias exists because the unversioned names the tests use (hera_ops.tm,
+# hera_plan.tm) are, on the server, copies of whatever release is newest today. That
+# is fine for a workstation mirror and useless for CI. Pinning the versioned file and
+# writing it into place under the plain name is what makes a run reproducible: the
+# kernels a build used are named here, and they change when someone edits this file,
+# not when ESA ships. Bumping a pin is a one-line, reviewable change - and a new
+# cache key, so CI refetches.
+#
+# The former_versions entries are pinned by the fixtures themselves: an mbi sidecar's
+# SPICE_MK field names the exact meta-kernel its geometry was generated against
+# (src/Tests/data/ASP_*.mbi.json says hera_plan_v180_20250616_001), and
+# HeraSpiceTests.loadKernelForMbiContent honours that. Those names only change when
+# the fixtures are regenerated.
+
+hera_ops_v182_20260527_001.tm -> hera_ops.tm
+hera_plan_v182_20260527_001.tm -> hera_plan.tm
+hera_ops_v172_20250312_001.tm
+hera_plan_v180_20250616_001.tm

--- a/scripts/spice-kernels.pins
+++ b/scripts/spice-kernels.pins
@@ -1,30 +1,9 @@
-# HERA SPICE meta-kernels the test suite loads, pinned to exact ESA SKD releases.
-#
-# scripts/fetch-spice-kernels.sh downloads each meta-kernel listed here plus every
-# kernel it names in KERNELS_TO_LOAD - nothing else. That closure is ~1.3 GB across
-# ~120 files; the full ESA dataset is ~11 GB, so do not be tempted to mirror the tree.
-#
-# Format, one entry per line:
+# HERA SPICE meta-kernels the test suite loads, pinned to exact ESA SKD releases, as
 #   <versioned meta-kernel file name>[ -> <name to also write into mk/>]
 #
-# Only the file name: ESA keeps the newest release in kernels/mk/ and moves it to
-# kernels/mk/former_versions/ the moment the next one is published (which happens
-# every few weeks), so the fetch script looks in both. A pin that named a directory
-# would break on ESA's release schedule rather than on ours.
-#
-# The alias exists because the unversioned names the tests use (hera_ops.tm,
-# hera_plan.tm) are, on the server, copies of whatever release is newest today. That
-# is fine for a workstation mirror and useless for CI. Pinning the versioned file and
-# writing it into place under the plain name is what makes a run reproducible: the
-# kernels a build used are named here, and they change when someone edits this file,
-# not when ESA ships. Bumping a pin is a one-line, reviewable change - and a new
-# cache key, so CI refetches.
-#
-# The former_versions entries are pinned by the fixtures themselves: an mbi sidecar's
-# SPICE_MK field names the exact meta-kernel its geometry was generated against
-# (src/Tests/data/ASP_*.mbi.json says hera_plan_v180_20250616_001), and
-# HeraSpiceTests.loadKernelForMbiContent honours that. Those names only change when
-# the fixtures are regenerated.
+# Why they are pinned, why two of them have no alias, and how to bump one:
+# docs/tests/SpiceKernels.md. Kept lean on purpose -- this file is the CI cache key,
+# so editing even a comment costs a refetch.
 
 hera_ops_v182_20260527_001.tm -> hera_ops.tm
 hera_plan_v182_20260527_001.tm -> hera_plan.tm

--- a/src/PRo3D.Base/InstrumentProjection.fs
+++ b/src/PRo3D.Base/InstrumentProjection.fs
@@ -95,6 +95,17 @@ module InstrumentProjection =
     // per-thread reentrant, so nesting (projectOnto* calls getLookAt*) is safe.
     let private spiceCallLock = obj()
 
+    /// Runs `f` as one unit against every SPICE-touching call in this module.
+    ///
+    /// For callers that *replace* the kernel pool -- CooTransformation.switchKernel does a
+    /// DeInit + Init + furnsh -- rather than read from it. A swap landing between the
+    /// getRelState and getRotationTrafo of one projection answers it from two different
+    /// kernel sets; a swap landing inside a native call takes the process down with an
+    /// access violation. Neither is something the reader side can defend against, so the
+    /// swapper has to take the same lock. Monitor is reentrant, so wrapping a whole
+    /// load-then-project sequence in this is fine.
+    let withSpiceLock (f : unit -> 'a) : 'a = lock spiceCallLock f
+
     let getLookAt (viewerBody : string) (observer : string) (referenceFrame : string) (supportBody : string) (time : DateTime) =
         lock spiceCallLock (fun () ->
             let afc1Pos = CooTransformation.getRelState viewerBody supportBody observer time referenceFrame

--- a/src/PRo3D.Base/InstrumentProjection.fs
+++ b/src/PRo3D.Base/InstrumentProjection.fs
@@ -95,15 +95,12 @@ module InstrumentProjection =
     // per-thread reentrant, so nesting (projectOnto* calls getLookAt*) is safe.
     let private spiceCallLock = obj()
 
-    /// Runs `f` as one unit against every SPICE-touching call in this module.
+    /// Runs `f` as one unit against every SPICE call in this module.
     ///
-    /// For callers that *replace* the kernel pool -- CooTransformation.switchKernel does a
-    /// DeInit + Init + furnsh -- rather than read from it. A swap landing between the
-    /// getRelState and getRotationTrafo of one projection answers it from two different
-    /// kernel sets; a swap landing inside a native call takes the process down with an
-    /// access violation. Neither is something the reader side can defend against, so the
-    /// swapper has to take the same lock. Monitor is reentrant, so wrapping a whole
-    /// load-then-project sequence in this is fine.
+    /// For callers that replace the kernel pool rather than read it -- switchKernel is
+    /// DeInit + Init + furnsh. A swap landing between the getRelState and getRotationTrafo
+    /// of one projection answers it from two kernel sets; a swap landing inside a native
+    /// call is an access violation. Reentrant, so a whole load-then-project sequence fits.
     let withSpiceLock (f : unit -> 'a) : 'a = lock spiceCallLock f
 
     let getLookAt (viewerBody : string) (observer : string) (referenceFrame : string) (supportBody : string) (time : DateTime) =

--- a/src/Tests/DidymosProjectionSpiceTest.fs
+++ b/src/Tests/DidymosProjectionSpiceTest.fs
@@ -32,7 +32,7 @@ let private reportedTime = DateTime.Parse("2027-03-03T03:05:00", CultureInfo.Inv
 // corrupting whichever test happens to run afterward. Use the same tracked mechanism
 // InstrumentProjectionComparisonTest.fs already uses instead.
 let private planKernelPath =
-    Path.Combine(HeraSpiceTests.spiceRoot, "spice", "kernels", "mk", "former_versions", "hera_plan_v180_20250616_001.tm")
+    Path.Combine(HeraSpiceTests.mkDir, "former_versions", "hera_plan_v180_20250616_001.tm")
     |> Path.GetFullPath
 
 let private ensurePlanKernel () : unit =

--- a/src/Tests/HeraSpiceTests.fs
+++ b/src/Tests/HeraSpiceTests.fs
@@ -21,19 +21,12 @@ module Coo = PRo3D.Base.CooTransformation
 
 let logDir = Path.Combine(".", "logs")
 
-/// The `kernels` directory of a HERA SPICE dataset, i.e. the directory holding
-/// `mk`, `ck`, `spk`, ... .
+/// The `kernels` directory of a HERA dataset -- the one holding `mk`, `ck`, `spk`, ... .
 ///
-/// PRO3D_SPICE_KERNELS is the documented way in - the same variable PRo3D.Tool reads,
-/// with the same tolerance: point it either at the dataset root (which has `kernels/mk`)
-/// or straight at the `kernels` directory. CI sets it to whatever
-/// scripts/fetch-spice-kernels.sh downloaded.
-///
-/// Without the variable, fall back to a `spice` mirror checked out next to the PRo3D
-/// clone, which is how the developer machines these tests were written on are laid out.
-/// The fallback is also what a missing/misspelled path degrades to - the point of
-/// resolution here is only to find the kernels, not to diagnose; `hasHera` below turns
-/// "not found" into skipped tests either way.
+/// From $PRO3D_SPICE_KERNELS, which may name either the dataset root or `kernels` itself
+/// (as PRo3D.Tool reads it); otherwise a `spice` mirror next to the PRo3D clone. Not
+/// found means `hasHera` is false and the kernel tests skip.
+/// See docs/tests/SpiceKernels.md.
 let kernelsDir =
     let sibling = Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "..", "spice", "kernels")
     let fromEnv =
@@ -49,12 +42,10 @@ let mkDir = Path.Combine(kernelsDir, "mk")
 
 let spiceFileName = Path.Combine(mkDir, "hera_ops.tm")
 
-// HERA tests need the HERA mission kernels, which are far too large to commit
-// (the meta-kernels these tests load close over ~1.3 GB). They self-skip when the
-// kernels are absent, or when --skip-hera is passed (runTests uses this for a
-// deterministic kernel-free run). Kernel-independent SPICE coverage lives in
-// SpiceTests.fs and always runs. (Adopted from releases/6.0.0.)
-// CI gets the kernels via scripts/fetch-spice-kernels.sh - see docs/SpiceKernels.md.
+// The HERA mission kernels are ~1.3 GB, too large to commit. These tests self-skip
+// without them, and on --skip-hera even with them (runTests passes it, for a
+// deterministic kernel-free run). Kernel-independent SPICE coverage is in SpiceTests.fs.
+// CI gets them via scripts/fetch-spice-kernels.sh; see docs/tests/SpiceKernels.md.
 /// Public so other kernel-using tests can honour the flag too: --skip-hera promises a
 /// deterministic kernel-free run even on a machine that has the kernels.
 let skipHeraRequested =
@@ -75,50 +66,27 @@ let init () =
     { new IDisposable with
         member x.Dispose() =
             CooTransformation.DeInit()
-            // DeInit empties the kernel pool, so whatever ensureKernelAt believed was
-            // loaded is gone. Say so, or the next ensureKernelAt for that same kernel
-            // decides it has nothing to do and every lookup after it comes back empty.
+            // DeInit empties the pool, so the record of what is loaded has to go too --
+            // otherwise the next ensureKernelAt for that kernel decides it need not act.
             lock spiceLock (fun () -> activeKernel.Value <- None) }
 
-// Different scenarios need different kernels: an mbi sidecar's own SPICE_MK field
-// names the exact meta-kernel it was generated against (e.g. HSH/AFC2 fixtures say
-// "hera_ops_v172_...", the ASPECT fixture says "hera_plan_v180_..."). Loading two
-// meta-kernels *on top of* each other was tried and breaks things: two ops
-// snapshots define conflicting CK segments for the same frame (HERA_HSH started
-// failing). There's also no native kernel-unload/kclear export to reach for
-// (checked PRo3D.SPICE-2's CooTransformation.dll exports directly -- only
-// AddSpiceKernel/DeInit/Init/GetRelState/GetPositionTransformationMatrix/etc,
-// nothing to unload a single kernel). So: track which single kernel is active,
-// and reset the pool whenever a scenario needs a different one -- verified
-// empirically that a fresh Init with just the target kernel resolves correctly
-// (both for an isolated hera_ops_v172 and an isolated hera_plan). Every caller
-// (fixture-driven or generic) must re-request its kernel immediately before
-// making SPICE calls, since anyone could have swapped it since the caller last
-// checked.
+// One meta-kernel at a time: there is no per-kernel unload, and layering two of them
+// makes conflicting CK segments for the same frame silently win over each other. So track
+// which one is active and reset the pool (DeInit + Init + furnsh) when a scenario needs a
+// different one. An mbi sidecar's SPICE_MK field says which that is. Every caller has to
+// re-request its kernel immediately before its SPICE calls, since anyone may have swapped
+// it since.
 //
-// Switching goes through PRo3D.Base.CooTransformation.switchKernel -- the same call the
-// viewer makes -- rather than reaching for AddSpiceKernel directly. Besides keeping the
-// tests honest about the app's own path, that brings the meta-kernel materialisation
-// with it: PATH_VALUES is rewritten to the absolute directory it always meant before the
-// furnsh, so nothing SPICE records depends on the process working directory.
-//
-// That matters more than it sounds. SPICE stores the file names a meta-kernel produces
-// exactly as they read at furnsh time, and DAF re-opens binary kernels (SPK/CK/DSK)
-// lazily, by the stored name, long afterwards. ESA's meta-kernels name them relatively
-// -- PATH_VALUES is '..' in mk/ and '../..' in mk/former_versions/ -- so this code used
-// to chdir into the meta-kernel's own directory and leave the process parked there.
-// That holds only while every meta-kernel lives in the same directory. Once fixtures
-// started naming archived kernels, a swap moved the working directory out from under
-// names DAF had already stored, and the damage surfaced nowhere near its cause: a failed
-// re-open, then SPICE(BADSUBSCRIPT) in dafah on the next DeInit (KCLEAR -> CKUPF ->
-// DAFCLS) tripping over the broken entry, then every later lookup returning
-// SPICE(DAFNOSUCHHANDLE) -- which reads exactly like a kernel with no coverage at the
-// requested epoch.
+// Switching goes through CooTransformation.switchKernel, as the viewer does, for two
+// reasons documented in docs/tests/SpiceKernels.md: it rewrites PATH_VALUES to an absolute
+// path before the furnsh, so nothing SPICE stores depends on the working directory (this
+// used to chdir instead, which broke once a swap crossed from mk/ to mk/former_versions/),
+// and the swap has to hold the projection lock, because it empties the pool.
 let private cooTrafoInitialized =
     lazy (
         // switchKernel reinitializes with the log directory initCooTrafo recorded, so the
-        // suite has to have gone through initCooTrafo at least once. It normally has
-        // (GeoJsonExportTest.init does it), but not when someone runs only these tests.
+        // suite has to have been through initCooTrafo at least once -- it has, unless
+        // someone runs only these tests.
         let appData =
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Pro3D")
         Coo.initCooTrafo None appData)
@@ -131,10 +99,8 @@ let ensureKernelAt (candidates : string list) : unit =
             let fullPath = Path.GetFullPath(path)
             if activeKernel.Value <> Some fullPath then
                 cooTrafoInitialized.Force()
-                // Under the lock the projection code uses, not just this module's own:
-                // switchKernel empties and refills the kernel pool, and doing that while
-                // another thread sits inside a SPICE call corrupts that call's result at
-                // best and segfaults the process at worst.
+                // The projection lock, not just this module's: a swap during another
+                // thread's SPICE call mixes two kernel sets, or crashes it.
                 InstrumentProjection.withSpiceLock (fun () ->
                     match Coo.switchKernel (Path.GetDirectoryName fullPath) (Path.GetFileName fullPath) with
                     | Some _ -> ()

--- a/src/Tests/HeraSpiceTests.fs
+++ b/src/Tests/HeraSpiceTests.fs
@@ -15,6 +15,7 @@ open Aardvark.Base
 
 open PRo3D.Extensions
 open PRo3D.Extensions.FSharp
+open PRo3D.SPICE
 
 module Coo = PRo3D.Base.CooTransformation
 
@@ -62,13 +63,22 @@ let hasHera = File.Exists spiceFileName && not skipHeraRequested
 
 do Aardvark.Base.Aardvark.UnpackNativeDependencies(typeof<CooTransformation.RelState>.Assembly)
 
+let private spiceLock = obj()
+let private activeKernel : string option ref = ref None
+
 let init () =
     if not (Directory.Exists(logDir)) then
         Directory.CreateDirectory(logDir) |> ignore
 
     let r = CooTransformation.Init(true, Path.Combine(logDir, "CooTrafo.log"), 4, 4)
     if r <> 0 then failwith "init failed."
-    { new IDisposable with member x.Dispose() = CooTransformation.DeInit()}
+    { new IDisposable with
+        member x.Dispose() =
+            CooTransformation.DeInit()
+            // DeInit empties the kernel pool, so whatever ensureKernelAt believed was
+            // loaded is gone. Say so, or the next ensureKernelAt for that same kernel
+            // decides it has nothing to do and every lookup after it comes back empty.
+            lock spiceLock (fun () -> activeKernel.Value <- None) }
 
 // Different scenarios need different kernels: an mbi sidecar's own SPICE_MK field
 // names the exact meta-kernel it was generated against (e.g. HSH/AFC2 fixtures say
@@ -79,14 +89,39 @@ let init () =
 // (checked PRo3D.SPICE-2's CooTransformation.dll exports directly -- only
 // AddSpiceKernel/DeInit/Init/GetRelState/GetPositionTransformationMatrix/etc,
 // nothing to unload a single kernel). So: track which single kernel is active,
-// and swap via DeInit+Init+AddSpiceKernel whenever a scenario needs a different
-// one -- verified empirically that a fresh Init with just the target kernel
-// resolves correctly (both for an isolated hera_ops_v172 and an isolated
-// hera_plan). Every caller (fixture-driven or generic) must re-request its
-// kernel immediately before making SPICE calls, since anyone could have swapped
-// it since the caller last checked.
-let private spiceLock = obj()
-let private activeKernel : string option ref = ref None
+// and reset the pool whenever a scenario needs a different one -- verified
+// empirically that a fresh Init with just the target kernel resolves correctly
+// (both for an isolated hera_ops_v172 and an isolated hera_plan). Every caller
+// (fixture-driven or generic) must re-request its kernel immediately before
+// making SPICE calls, since anyone could have swapped it since the caller last
+// checked.
+//
+// Switching goes through PRo3D.Base.CooTransformation.switchKernel -- the same call the
+// viewer makes -- rather than reaching for AddSpiceKernel directly. Besides keeping the
+// tests honest about the app's own path, that brings the meta-kernel materialisation
+// with it: PATH_VALUES is rewritten to the absolute directory it always meant before the
+// furnsh, so nothing SPICE records depends on the process working directory.
+//
+// That matters more than it sounds. SPICE stores the file names a meta-kernel produces
+// exactly as they read at furnsh time, and DAF re-opens binary kernels (SPK/CK/DSK)
+// lazily, by the stored name, long afterwards. ESA's meta-kernels name them relatively
+// -- PATH_VALUES is '..' in mk/ and '../..' in mk/former_versions/ -- so this code used
+// to chdir into the meta-kernel's own directory and leave the process parked there.
+// That holds only while every meta-kernel lives in the same directory. Once fixtures
+// started naming archived kernels, a swap moved the working directory out from under
+// names DAF had already stored, and the damage surfaced nowhere near its cause: a failed
+// re-open, then SPICE(BADSUBSCRIPT) in dafah on the next DeInit (KCLEAR -> CKUPF ->
+// DAFCLS) tripping over the broken entry, then every later lookup returning
+// SPICE(DAFNOSUCHHANDLE) -- which reads exactly like a kernel with no coverage at the
+// requested epoch.
+let private cooTrafoInitialized =
+    lazy (
+        // switchKernel reinitializes with the log directory initCooTrafo recorded, so the
+        // suite has to have gone through initCooTrafo at least once. It normally has
+        // (GeoJsonExportTest.init does it), but not when someone runs only these tests.
+        let appData =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Pro3D")
+        Coo.initCooTrafo None appData)
 
 let ensureKernelAt (candidates : string list) : unit =
     lock spiceLock (fun () ->
@@ -95,18 +130,15 @@ let ensureKernelAt (candidates : string list) : unit =
         | Some path ->
             let fullPath = Path.GetFullPath(path)
             if activeKernel.Value <> Some fullPath then
-                CooTransformation.DeInit()
-                let r = CooTransformation.Init(true, Path.Combine(logDir, "CooTrafo.log"), 4, 4)
-                if r <> 0 then failwith "init failed."
-                // Deliberately not restored: some binary kernels (e.g. CK data for
-                // instrument frames) get reopened by CSPICE on later queries, not
-                // just at furnsh_c time, and that reopen fails with FILEOPENFAIL if
-                // the CWD has since moved away from the kernel's own directory.
-                // Leave CWD parked here for as long as this kernel stays active.
-                System.Environment.CurrentDirectory <- Path.GetDirectoryName(fullPath)
-                let addResult = CooTransformation.AddSpiceKernel(fullPath)
-                if addResult <> 0 then
-                    printfn "[HeraSpiceTests] failed to add kernel %s (result %d)" fullPath addResult
+                cooTrafoInitialized.Force()
+                // Under the lock the projection code uses, not just this module's own:
+                // switchKernel empties and refills the kernel pool, and doing that while
+                // another thread sits inside a SPICE call corrupts that call's result at
+                // best and segfaults the process at worst.
+                InstrumentProjection.withSpiceLock (fun () ->
+                    match Coo.switchKernel (Path.GetDirectoryName fullPath) (Path.GetFileName fullPath) with
+                    | Some _ -> ()
+                    | None -> printfn "[HeraSpiceTests] failed to load kernel %s" fullPath)
                 activeKernel.Value <- Some fullPath)
 
 let ensureOpsKernel () : unit =

--- a/src/Tests/HeraSpiceTests.fs
+++ b/src/Tests/HeraSpiceTests.fs
@@ -19,14 +19,41 @@ open PRo3D.Extensions.FSharp
 module Coo = PRo3D.Base.CooTransformation
 
 let logDir = Path.Combine(".", "logs")
-let spiceRoot = Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "..")
-let spiceFileName = Path.Combine(spiceRoot, "spice", "kernels", "mk", "hera_ops.tm")
-let private mkDir = Path.Combine(spiceRoot, "spice", "kernels", "mk")
 
-// HERA tests need the (non-public) HERA mission kernels. They self-skip when
-// those are absent (e.g. in CI), or when --skip-hera is passed (runTests uses
-// this for a deterministic kernel-free run). Kernel-independent SPICE coverage
-// lives in SpiceTests.fs and always runs. (Adopted from releases/6.0.0.)
+/// The `kernels` directory of a HERA SPICE dataset, i.e. the directory holding
+/// `mk`, `ck`, `spk`, ... .
+///
+/// PRO3D_SPICE_KERNELS is the documented way in - the same variable PRo3D.Tool reads,
+/// with the same tolerance: point it either at the dataset root (which has `kernels/mk`)
+/// or straight at the `kernels` directory. CI sets it to whatever
+/// scripts/fetch-spice-kernels.sh downloaded.
+///
+/// Without the variable, fall back to a `spice` mirror checked out next to the PRo3D
+/// clone, which is how the developer machines these tests were written on are laid out.
+/// The fallback is also what a missing/misspelled path degrades to - the point of
+/// resolution here is only to find the kernels, not to diagnose; `hasHera` below turns
+/// "not found" into skipped tests either way.
+let kernelsDir =
+    let sibling = Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "..", "spice", "kernels")
+    let fromEnv =
+        match Environment.GetEnvironmentVariable "PRO3D_SPICE_KERNELS" with
+        | null | "" -> []
+        | value -> [ value; Path.Combine(value, "kernels") ]
+    fromEnv @ [ sibling ]
+    |> List.tryFind (fun dir -> Directory.Exists(Path.Combine(dir, "mk")))
+    |> Option.defaultValue sibling
+
+/// Directory holding the meta-kernels (`hera_ops.tm`, `hera_plan.tm`, `former_versions/...`).
+let mkDir = Path.Combine(kernelsDir, "mk")
+
+let spiceFileName = Path.Combine(mkDir, "hera_ops.tm")
+
+// HERA tests need the HERA mission kernels, which are far too large to commit
+// (the meta-kernels these tests load close over ~1.3 GB). They self-skip when the
+// kernels are absent, or when --skip-hera is passed (runTests uses this for a
+// deterministic kernel-free run). Kernel-independent SPICE coverage lives in
+// SpiceTests.fs and always runs. (Adopted from releases/6.0.0.)
+// CI gets the kernels via scripts/fetch-spice-kernels.sh - see docs/SpiceKernels.md.
 /// Public so other kernel-using tests can honour the flag too: --skip-hera promises a
 /// deterministic kernel-free run even on a machine that has the kernels.
 let skipHeraRequested =

--- a/src/Tests/InstrumentProjectionComparisonTest.fs
+++ b/src/Tests/InstrumentProjectionComparisonTest.fs
@@ -197,24 +197,39 @@ let tests () =
                 Expect.isSome hit "quaternion-based center ray should hit round Didymos"
         }
 
-        // Reproduces the original race (HSH + ASPECT interleaved across threads) and checks
-        // every concurrent HSH result still matches a fresh sequential baseline.
+        // Reproduces the original race -- projectOntoQuat and projectOnto, which are each
+        // several native calls, running interleaved across threads -- and checks every
+        // concurrent result still matches a fresh sequential baseline.
+        //
+        // All 50 items compute the HSH projection, and deliberately so: they used to be
+        // half HSH and half ASPECT, which is not a scenario that can be given a meaning.
+        // Those two fixtures name different meta-kernels (ops_v172 vs plan_v180), only one
+        // meta-kernel can be loaded at a time, and loading is DeInit + Init + furnsh. Half
+        // the threads were therefore emptying the kernel pool underneath the other half:
+        // the mild outcome was an HSH lookup answered by a kernel with no HERA_HSH frame
+        // (SPICE(UNKNOWNFRAME), dropped by the Array.choose below, so the check quietly
+        // measured almost nothing), and the usual outcome was an access violation inside a
+        // native call whose kernels had just been freed.
+        //
+        // One fixture keeps the pool constant for the whole parallel section -- parseMbi's
+        // ensureKernelAt sees the kernel it wants already active and does nothing -- so
+        // what races is exactly what this test is about, and every result has to resolve.
+        // Cross-kernel behaviour is covered by the sequential tests above, which is the
+        // only place it can be covered.
         test "concurrent projectOntoQuat/projectOnto calls no longer corrupt each other's results" {
             let baseline =
                 match computeHshAngle () with
                 | Some angle -> angle
                 | None -> failtest "baseline HSH computation returned None -- cannot run the concurrency check"
 
-            let work =
-                Array.append
-                    (Array.init 25 (fun _ -> async { return Choice1Of2 (computeHshAngle ()) }))
-                    (Array.init 25 (fun _ -> async { return Choice2Of2 (computeAspectResolves ()) }))
-
+            let work = Array.init 50 (fun _ -> async { return computeHshAngle () })
             let results = work |> Async.Parallel |> Async.RunSynchronously
-            let hshAngles = results |> Array.choose (function Choice1Of2 a -> a | _ -> None)
-            Expect.isGreaterThan hshAngles.Length 0 "expected at least one concurrent HSH result to resolve"
 
-            for angle in hshAngles do
+            let unresolved = results |> Array.filter Option.isNone |> Array.length
+            Expect.equal unresolved 0
+                "every concurrent HSH computation must resolve -- the kernel it needs stays loaded throughout"
+
+            for angle in results |> Array.choose id do
                 Expect.floatClose Accuracy.high angle baseline
                     (sprintf "concurrent HSH result %.6f drifted from baseline %.6f -- SPICE calls are racing again" angle baseline)
         }

--- a/src/Tests/InstrumentProjectionComparisonTest.fs
+++ b/src/Tests/InstrumentProjectionComparisonTest.fs
@@ -197,25 +197,17 @@ let tests () =
                 Expect.isSome hit "quaternion-based center ray should hit round Didymos"
         }
 
-        // Reproduces the original race -- projectOntoQuat and projectOnto, which are each
-        // several native calls, running interleaved across threads -- and checks every
-        // concurrent result still matches a fresh sequential baseline.
+        // Reproduces the original race: projectOntoQuat and projectOnto, each several
+        // native calls, running interleaved across threads.
         //
-        // All 50 items compute the HSH projection, and deliberately so: they used to be
-        // half HSH and half ASPECT, which is not a scenario that can be given a meaning.
-        // Those two fixtures name different meta-kernels (ops_v172 vs plan_v180), only one
-        // meta-kernel can be loaded at a time, and loading is DeInit + Init + furnsh. Half
-        // the threads were therefore emptying the kernel pool underneath the other half:
-        // the mild outcome was an HSH lookup answered by a kernel with no HERA_HSH frame
-        // (SPICE(UNKNOWNFRAME), dropped by the Array.choose below, so the check quietly
-        // measured almost nothing), and the usual outcome was an access violation inside a
-        // native call whose kernels had just been freed.
-        //
-        // One fixture keeps the pool constant for the whole parallel section -- parseMbi's
-        // ensureKernelAt sees the kernel it wants already active and does nothing -- so
-        // what races is exactly what this test is about, and every result has to resolve.
-        // Cross-kernel behaviour is covered by the sequential tests above, which is the
-        // only place it can be covered.
+        // All 50 items use one fixture. Half HSH and half ASPECT, as this was, is not a
+        // scenario with a meaning: those two name different meta-kernels, only one loads
+        // at a time, and loading is DeInit + Init + furnsh -- so half the threads were
+        // freeing the kernels the other half were reading (usually an access violation,
+        // otherwise an HSH lookup answered by the plan kernel, which came back None and
+        // was dropped by the Array.choose). One fixture keeps the pool constant, so the
+        // race is the intended one and every result has to resolve. Cross-kernel
+        // behaviour is covered by the sequential tests above.
         test "concurrent projectOntoQuat/projectOnto calls no longer corrupt each other's results" {
             let baseline =
                 match computeHshAngle () with

--- a/src/Tests/Pro3DToolTests.fs
+++ b/src/Tests/Pro3DToolTests.fs
@@ -176,8 +176,7 @@ let private sunAngleTests =
             // The ASPECT sidecar names a planning kernel; ops does not cover the epoch.
             // Going through ensureKernelAt reuses the suite's tracking, so this is a no-op
             // when that kernel is already active.
-            let mkDir = Path.GetDirectoryName HeraSpiceTests.spiceFileName
-            HeraSpiceTests.ensureKernelAt [ Path.Combine(mkDir, "hera_plan.tm"); HeraSpiceTests.spiceFileName ]
+            HeraSpiceTests.ensureKernelAt [ Path.Combine(HeraSpiceTests.mkDir, "hera_plan.tm"); HeraSpiceTests.spiceFileName ]
 
             let outDir = Path.Combine(Path.GetTempPath(), "pro3d-tool-tests", Guid.NewGuid().ToString("N"))
             Directory.CreateDirectory outDir |> ignore
@@ -267,8 +266,7 @@ let private simulateImageTests =
             | Result.Error e -> skiptest (sprintf "no resolvable ASPECT image: %s" e)
             | Result.Ok img ->
 
-            let mkDir = Path.GetDirectoryName HeraSpiceTests.spiceFileName
-            HeraSpiceTests.ensureKernelAt [ Path.Combine(mkDir, "hera_plan.tm"); HeraSpiceTests.spiceFileName ]
+            HeraSpiceTests.ensureKernelAt [ Path.Combine(HeraSpiceTests.mkDir, "hera_plan.tm"); HeraSpiceTests.spiceFileName ]
 
             let outDir = Path.Combine(Path.GetTempPath(), "pro3d-tool-tests", Guid.NewGuid().ToString("N"))
             Directory.CreateDirectory outDir |> ignore


### PR DESCRIPTION
The kernel-backed tests only ever ran on a workstation with a full ESA mirror in a sibling `spice` directory, so CI covered the `--skip-hera` subset and the projection fixtures went unchecked on every PR. This gets the kernels onto GitHub Actions — and fixes the two SPICE bugs that surfaced the moment the whole suite ran with kernels present.

## Getting the kernels (`ci: run the HERA SPICE-kernel tests on GitHub Actions`)

Fetch what the suite actually loads instead of mirroring anything. A HERA meta-kernel names its kernels in `KERNELS_TO_LOAD`, so the closure of the four meta-kernels the tests open is **119 files, 1.23 GiB**, against ~11 GB for the dataset (and a git repo carrying every version ever published). ESA serves it over public HTTPS with range support, so `scripts/fetch-spice-kernels.sh` is resumable and runs 8 downloads at a time.

**Pinned by version.** The unversioned names the tests open — `hera_ops.tm`, `hera_plan.tm` — are copies of whatever release is newest, and ESA publishes every few weeks, moving the previous file into `former_versions/` as it goes. It did exactly that to the release this branch was written against while the branch was being written. `scripts/spice-kernels.pins` names versioned files, resolved in `mk/` then `mk/former_versions/`, and the aliased ones are written into `mk/` under the plain names — rewriting `PATH_VALUES` back to `'..'`, the single line archiving changes. The result is byte-identical to a workstation mirror's `hera_ops.tm`.

**Safe to run on a cache hit.** The script verifies the tree against its own manifest offline and exits in about a second; it repairs a partial restore rather than letting it surface later as a puzzling error inside CSPICE. The manifest records which pins produced it, so a tree restored via `restore-keys` after a pin bump refetches the changed closure instead of being mistaken for complete.

Tests find the tree through `PRO3D_SPICE_KERNELS` (the variable `pro3d-tool` already reads, equally tolerant of root-or-`kernels`), falling back to the sibling mirror, so existing workstations are unaffected. The job is Linux-only: kernels are platform-independent data, and a 1.3 GB cache entry per OS would push the paket caches out of the repository's 10 GB budget.

## What that uncovered (`fix(tests): stop the kernel swap from corrupting SPICE state`)

Running the whole suite with kernels present died mid-run — `SPICE(BADSUBSCRIPT)` in `dafah`, then every later lookup failing with `SPICE(DAFNOSUCHHANDLE)`, then the process going down — and on the way there the two `pro3d-tool` tests reported *"the loaded kernel has no coverage at this epoch"* for epochs their kernel covers perfectly well when the test runs on its own. Two causes, both about how the kernel gets loaded rather than about the kernel.

**The working directory.** SPICE stores the file names a meta-kernel produces exactly as they read at furnsh time, and DAF re-opens binary kernels lazily, by the stored name, long afterwards. ESA's meta-kernels name them relatively (`PATH_VALUES` is `'..'` in `mk/`, `'../..'` in `mk/former_versions/`), so `ensureKernelAt` chdir'd into the meta-kernel's directory and parked the process there. That holds only while every meta-kernel lives in the same directory; once fixtures started naming archived kernels, a swap moved the working directory out from under names DAF had already stored. `PRo3D.Base.CooTransformation` already solved this for the viewer — `materializeMetaKernel` rewrites `PATH_VALUES` to an absolute directory before the furnsh — so the tests now go through `switchKernel` and inherit it. Nothing chdirs any more.

**The other thread.** Swapping is `DeInit + Init + furnsh`: it empties the kernel pool. The concurrency test in `InstrumentProjectionComparisonTest` ran 25 HSH computations against 25 ASPECT ones, and those two fixtures name different meta-kernels — so half the threads were freeing the kernels the other half were reading. `InstrumentProjection` now exposes `withSpiceLock` so a caller replacing the pool takes the same lock the readers do, and the concurrent section uses one fixture throughout. That is not a loss of coverage: with two kernels, an HSH lookup answered by the plan kernel returned `None` and was dropped by the `Array.choose`, so the drift check was measuring whatever happened to survive. Now every result must resolve and match the baseline.

## Verified

- All 119 closure URLs checked against ESA: sizes match a workstation mirror byte for byte.
- Fetch script exercised end to end — cold, warm, missing file, truncated, oversized, pin bump, malformed meta-kernel — plus real HTTPS download and resume-repair.
- Full suite with kernels and private data: **482 tests, 480 passed, 13 ignored, 2 failed** (it used to crash mid-run). Zero `BADSUBSCRIPT` / `DAFNOSUCHHANDLE` in the log.
- CI-shaped run (kernels, no private data, no GL): **472 passed, 21 ignored, 2 failed**.
- Kernel-free subset (`runTests.sh`, what the four-OS matrix runs): **445 passed**.

## Known failure this does not fix

Both remaining failures are `snapshot-sun-lighting`. Its subprocess fails to render its *first* frame (`Could not render image …frame_a.png`, `col = None` in `RenderingUtils.fs:238`) while `frame_b` renders and saves fine — fresh process, one kernel, no swaps, no SPICE error in its log; the preceding line is `[Viewer] Message not handled: SetRenderViewportSize [640, 480]`. There is also an unrelated unhandled `Task.Dispose` exception at `PRo3D.Snapshots/Program.fs:234` on shutdown. Pre-existing, in `PRo3D.SimulatedViews`, and it reproduces in isolation.

Worth knowing: these tests gate on `PRO3D_SPICE_KERNELS`, so they have been skipping on machines that never set it. Now that setting it is the documented way to run the suite, anyone with the `C:\pro3ddata` workshop fixture and a GPU will start seeing them fail. On CI they still skip — no fixture, no GL context, no `PRo3D.Snapshots.exe`.

## Docs

`docs/tests/SpiceKernels.md` is new — where the kernels come from, why the pins exist and how to bump them, what CI does, and the rule the second commit is about: load kernels through `switchKernel` under `withSpiceLock`, never by chdir'ing. Linked from `docs/spice.md` and `docs/tests/TestData.md`; `AGENTS.md` and the `runAllTests` headers point at it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcCDi43HPticvCkzcQtZUo
