### PR TITLE
docs(spice): say what a pins comment edit actually costs

### DIFF
--- a/docs/tests/SpiceKernels.md
+++ b/docs/tests/SpiceKernels.md
@@ -102,7 +102,10 @@ the kernel-backed suite in a separate `spice-tests` job:
 
 1. `actions/cache` on `spice/`, keyed by `hashFiles('scripts/spice-kernels.pins')` — an
    ESA release does not invalidate it, a pin bump does. `restore-keys` hands a bumped run
-   the previous tree, so it refetches one closure instead of four.
+   the previous tree, so it refetches one closure instead of four. Note the two hashes
+   are not the same: `hashFiles` covers the whole file, while the script's completeness
+   check hashes only the pin lines — so editing a comment there costs a new 1.2 GB cache
+   entry, but no downloads.
 2. `bash scripts/fetch-spice-kernels.sh spice`, cache hit or not.
 3. `PRO3D_SPICE_KERNELS=$GITHUB_WORKSPACE/spice bash ./runAllTests.sh`.
 

--- a/scripts/spice-kernels.pins
+++ b/scripts/spice-kernels.pins
@@ -2,8 +2,9 @@
 #   <versioned meta-kernel file name>[ -> <name to also write into mk/>]
 #
 # Why they are pinned, why two of them have no alias, and how to bump one:
-# docs/tests/SpiceKernels.md. Kept lean on purpose -- this file is the CI cache key,
-# so editing even a comment costs a refetch.
+# docs/tests/SpiceKernels.md. Kept lean on purpose -- this file is the CI cache key, so
+# editing even a comment costs a fresh 1.2 GB cache entry (not a refetch: the fetch
+# script hashes the pin lines alone, so a restored tree still verifies as complete).
 
 hera_ops_v182_20260527_001.tm -> hera_ops.tm
 hera_plan_v182_20260527_001.tm -> hera_plan.tm


### PR DESCRIPTION
Follow-up to #734, correcting one sentence I got wrong there.

`scripts/spice-kernels.pins` said "this file is the CI cache key, so editing even a comment costs a refetch". The first cache-hit run disproved it — that run *had* an edited comment:

```
Cache SPICE kernels   Cache restored successfully
Fetch SPICE kernels   SPICE kernels -> spice/kernels
                      125 kernels present and complete (manifest verified, no downloads)
```

0.26 s, zero requests. Two different hashes are involved and I conflated them:

- `actions/cache` keys on `hashFiles` over the **whole file**, so a comment edit misses the exact key — `restore-keys` then hands the run the previous tree.
- The fetch script's completeness check hashes the **pin lines alone**, comments stripped, so the restored tree still verifies as complete.

Net cost of a comment edit: a fresh 1.2 GB cache entry, no downloads. Keeping the file lean is still worth doing, just not for the reason stated.

Fixes the comment and adds the distinction to the CI section of `docs/tests/SpiceKernels.md`. Comment and prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcCDi43HPticvCkzcQtZUo
