### PR TITLE
fix(viewplan): draw the footprint boundary again (#733), plus the 5.7 UI and version fixes

### DIFF
--- a/Build.fs
+++ b/Build.fs
@@ -71,6 +71,26 @@ let patchAardiumVersion (version : string) =
     let patched = rx.Replace(text, sprintf "\"version\": \"%s\"" version, 1)
     File.WriteAllText(path, patched)
 
+// The viewer's version is a source literal, stamped here from the release notes
+// before the publish that follows. Unstamped builds (dotnet run, IDE, plain
+// build.cmd) therefore report "development build" rather than a stale number -
+// which is how issue #733 arrived reporting 5.4.0 against a 6.0.0 build.
+// Fail loudly rather than shipping the placeholder if the line ever moves.
+let patchViewerVersion (version : string) =
+    let path = "src/PRo3D.Viewer/Program.fs"
+    let mutable found = false
+    let patched =
+        File.ReadAllLines path
+        |> Array.map (fun line ->
+            if line.StartsWith "let viewerVersion" then
+                found <- true
+                sprintf "let viewerVersion       = \"%s\"" version
+            else line
+        )
+    if not found then
+        failwithf "no 'let viewerVersion' line in %s - the release would ship the placeholder version" path
+    File.WriteAllLines(path, patched)
+
 
 //Target.create "Compile" (fun _ ->
 //    run dotnet "build" "src"
@@ -347,15 +367,7 @@ Target.create "CopyToElectron" (fun _ ->
         Directory.Delete(dotnetOutputPath, true)
 
     // 0.0 copy version over into source code...
-    let programFs = File.ReadAllLines "src/PRo3D.Viewer/Program.fs"
-    let patched =
-        programFs
-        |> Array.map (fun line ->
-            if line.StartsWith "let viewerVersion" then
-                sprintf "let viewerVersion       = \"%s\"" notes.NugetVersion
-            else line
-        )
-    File.WriteAllLines("src/PRo3D.Viewer/Program.fs", patched)
+    patchViewerVersion notes.NugetVersion
 
     // 0.1 keep aardium/package.json version in sync so electron-builder's
     // release tag (v{version}) matches the FAKE GitHubRelease draft tag.
@@ -448,15 +460,7 @@ Target.create "TestUnpack" (fun _ ->
 Target.create "Publish" (fun _ ->
 
     // 0.0 copy version over into source code...
-    let programFs = File.ReadAllLines "src/PRo3D.Viewer/Program.fs"
-    let patched = 
-        programFs 
-        |> Array.map (fun line -> 
-            if line.StartsWith "let viewerVersion" then 
-                sprintf "let viewerVersion       = \"%s\"" notes.NugetVersion 
-            else line
-        )
-    File.WriteAllLines("src/PRo3D.Viewer/Program.fs", patched)
+    patchViewerVersion notes.NugetVersion
 
     if Directory.Exists "bin/publish" then 
         Directory.Delete("bin/publish", true)

--- a/docs/Build-Deploy-System.md
+++ b/docs/Build-Deploy-System.md
@@ -108,6 +108,18 @@ all resources should be embedded using dotnet embedded resources to allow "singl
 
 - title bar version is fixed up by "publish" target using string replace
 
+The literal in `src/PRo3D.Viewer/Program.fs` is **`"development build"`**, not a version
+number. `patchViewerVersion` in `Build.fs` rewrites that line from `notes.NugetVersion` at
+the top of both `CopyToElectron` (→ `PublishToElectron`, the installers) and `Publish`
+(→ `UploadStandalone`, the standalone zip), before each target's own `DotNet.publish`
+rebuilds — so every published artifact carries the real version and only unstamped builds
+(`dotnet run`, the IDE, a plain `build.cmd`) show the placeholder.
+
+Keeping a version number there instead was actively harmful: it goes stale silently, and
+[#733](https://github.com/pro3d-space/PRo3D/issues/733) was filed against a build that
+reported `5.4.0` while running 6.0.0 code. `patchViewerVersion` fails the build if the
+`let viewerVersion` line ever moves, rather than shipping the placeholder.
+
 # Manual build and upload to github release
 
 - prepare the github_token env variable https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token, 

--- a/src/PRo3D.Core/AardvarkUIReworks.fs
+++ b/src/PRo3D.Core/AardvarkUIReworks.fs
@@ -41,11 +41,14 @@ module NoSemUi =
 
     let inline private thing a = { value = a }
 
+    // Aardvark.UI 5.7 moved these under ./resources/fomantic/ and dropped essentialstuff.js,
+    // which defines the jQuery `numeric` plugin `numeric` boots with below. essentialstuff.js
+    // is vendored from 5.6.0 (in PRo3D.Viewer, as only the entry assembly serves ./resources).
     let private semui =
         [
-            { kind = Stylesheet; name = "semui"; url = "./resources/semantic.css" }
-            { kind = Stylesheet; name = "semui-overrides"; url = "./resources/semantic-overrides.css" }
-            { kind = Script; name = "semui"; url = "./resources/semantic.js" }
+            { kind = Stylesheet; name = "semui"; url = "./resources/fomantic/semantic.css" }
+            { kind = Stylesheet; name = "semui-overrides"; url = "./resources/fomantic/semantic-overrides.css" }
+            { kind = Script; name = "semui"; url = "./resources/fomantic/semantic.js" }
             { kind = Script; name = "essential"; url = "./resources/essentialstuff.js" }
         ]
 

--- a/src/PRo3D.Core/Surface/ImageProjectionOpcRendering.fs
+++ b/src/PRo3D.Core/Surface/ImageProjectionOpcRendering.fs
@@ -12,7 +12,21 @@ module ImageProjectionOpcExtensions =
 
     let projectionUniformMap : Map<string, obj -> Aardvark.GeoSpatial.Opc.PatchLod.RenderPatch -> IAdaptiveValue> =
         Map.ofList [
-            "ProjectedImagesLocalTrafos", (fun scope (patch : Aardvark.GeoSpatial.Opc.PatchLod.RenderPatch) -> 
+            // instrument clip <- patch local, for the view plan footprint (Shader.footprintV).
+            // Composed on the CPU in double like ProjectedImageModelViewProj below; the outer
+            // Sg.uniform of this name in ViewerUtils is only a placeholder and is shadowed here.
+            //
+            // Equivalent to the patch.trafo this used to be written against: patch.trafo is
+            // flattenStack (Local2Global :: modelTrafoStack), which folds to
+            // modelTrafo.Forward * Local2Global.Forward for ViewerModality.XYZ.
+            "FootprintModelViewProj", (fun scope (patch : Aardvark.GeoSpatial.Opc.PatchLod.RenderPatch) ->
+                let context = scope |> unbox<OpcRenderingExtensions.Context>
+                (context.footprintVP, context.modelTrafo)
+                ||> AVal.map2 (fun vp (m : Trafo3d) ->
+                    vp * m.Forward * patch.info.Local2Global.Forward
+                ) :> IAdaptiveValue
+            )
+            "ProjectedImagesLocalTrafos", (fun scope (patch : Aardvark.GeoSpatial.Opc.PatchLod.RenderPatch) ->
                 let context = scope |> unbox<OpcRenderingExtensions.Context> 
                 context.projectedImages |> AVal.bind (function 
                     | None -> AVal.constant Array.empty<M44f>

--- a/src/PRo3D.Viewer/PRo3D.Viewer.fsproj
+++ b/src/PRo3D.Viewer/PRo3D.Viewer.fsproj
@@ -85,6 +85,7 @@
     <EmbeddedResource Include="resources\calendar.css" />
     <EmbeddedResource Include="resources\calendar.js" />
     <EmbeddedResource Include="resources\utilities.js" />
+    <EmbeddedResource Include="resources\essentialstuff.js" />
     <Content Include="resources\rotationcubeXYZ\back.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/PRo3D.Viewer/Program.fs
+++ b/src/PRo3D.Viewer/Program.fs
@@ -1,4 +1,4 @@
-open System 
+﻿open System 
 
 //open System.Windows.Forms
 open System.Collections.Concurrent
@@ -44,7 +44,10 @@ type Result =
       result : string;
    }
 
-let viewerVersion       = "5.4.0"
+// Stamped from the top of PRODUCT_RELEASE_NOTES.md by Build.fs (patchViewerVersion)
+// before every published build. Anything that reports the placeholder below was not
+// produced by the release pipeline.
+let viewerVersion       = "development build"
 
 let catchDomainErrors   = false
 

--- a/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
+++ b/src/PRo3D.Viewer/Viewer/Viewer-Utils.fs
@@ -440,6 +440,10 @@ module ViewerUtils =
                     |> addRadiometryParameters surf
                     |> Sg.uniform "DepthVisible" depthVisible //(AVal.constant(true)) //
                     |> Sg.uniform "FootprintVisible" footprintVisible
+                    // Placeholder for non-PatchNode geometry under this scope (e.g. mesh
+                    // surfaces), which never draws a footprint. OPC patches shadow it with
+                    // the per-patch matrix from projectionUniformMap; identity here would
+                    // put every patch-local vertex outside footPrintF's [-1,1] test.
                     |> Sg.uniform "FootprintModelViewProj" (M44d.Identity |> AVal.constant)
                     |> Sg.applyFootprint footprintViewProj
                     |> Sg.noEvents

--- a/src/PRo3D.Viewer/resources/essentialstuff.js
+++ b/src/PRo3D.Viewer/resources/essentialstuff.js
@@ -1,0 +1,82 @@
+
+$.fn.numeric = function (ob, value) {
+
+    this.find("input").each(function () {
+
+        if ("numericsetvalue" in this) {
+            var setValue = this.numericsetvalue;
+            if (ob === "set") setValue(value, false);
+            return;
+        }
+
+        var config = { changed: function (v) { } };
+        var o = $.extend(config, ob);
+
+
+        var self = this;
+        var old = parseFloat(self.value);
+
+        function largeStep() {
+            var s = parseFloat(self.getAttribute("data-largestep"));
+            if (isNaN(s)) return 10.0;
+            else return s;
+        }
+
+        function formatFloat(value, decimal) {
+            return value.toPrecision(15)
+                .replace(/\.([0-9]*?)0+([eE][\+\-0-9]*$)?$/, ".$1$2")
+                .replace(/\.$/, "")
+                .replace(/\.([eE])/, "$1")
+                .replace("e", "E");
+        }
+
+        function setValue(value, raiseEvent) {
+            var initial = old;
+            try { initial = parseFloat(eval(value)); }
+            catch (e) { initial = old; }
+
+            var v = initial;
+            var min = parseFloat(self.min);
+            var max = parseFloat(self.max);
+
+            if (!isNaN(min) && v < min) { v = min; }
+            if (!isNaN(max) && v > max) { v = max; }
+
+            var o = old;
+            if (isNaN(v)) v = old;
+            else old = v;
+
+            if (o != v && raiseEvent) config.changed(v);
+            var str = formatFloat(v, 8);
+            self.value = str;
+        }
+
+        function step(dir) {
+            var step = parseFloat(self.step);
+            if (!step) step = 1.0;
+            setValue(parseFloat(self.value) + dir * step, true);
+        }
+
+        function checkKey(e) {
+            if ((e.key < "0" || e.key > "9") && e.key != "." && e.key != "+" && e.key != "-" && e.key != "E" && e.key != "e" && e.key != "*" && e.key != "/" && e.key != "(" && e.key != ")" && e.key != " ") e.preventDefault();
+
+        }
+
+        function down(e) {
+            if (e.keyCode == 38) { step(1); e.preventDefault(); }
+            else if (e.keyCode == 40) { step(-1); e.preventDefault(); }
+            else if (e.keyCode == 33) { step(largeStep()); e.preventDefault(); }
+            else if (e.keyCode == 34) { step(-largeStep()); e.preventDefault(); }
+            else if (e.keyCode == 13) setValue(e.target.value, true);
+            else if (e.keyCode == 27) setValue(old, true);
+        }
+
+        this["numericsetvalue"] = setValue;
+
+        $(this)
+            .bind('mousewheel', function (e) { step(-Math.sign(e.originalEvent.deltaY) * (e.originalEvent.shiftKey ? largeStep() : 1)); e.preventDefault(); })
+            .keypress(function (e) { checkKey(e); })
+            .keydown(function (e) { down(e); })
+            .change(function (e) { setValue(e.target.value, true); });
+    });
+};


### PR DESCRIPTION
Backport branch for the 6.0.0 line. Fixes #733 and two things found alongside it.

### 1. The footprint boundary is never drawn (#733)

Creating a view plan places the rover, lets you pick an instrument and shows the instrument view — only the outline on the surface is missing.

`21a570cc` (Mar 2025) moved the OPC per-patch uniform map out of `Surface.Sg.fs` into the shared `ImageProjectionOpcExtensions.projectionUniformMap`, and the `"FootprintModelViewProj"` entry was lost in the move. Nothing has computed it since: `Context.footprintVP` is still captured in `captureContext` but had no consumer, so the only value reaching `Shader.footprintV` was the outer placeholder uniform of that name in `ViewerUtils` — identity. OPC geometry is patch-local, so identity puts every vertex far outside the `[-1,1]` test in `footPrintF`.

The entry is restored, composed on the CPU in double like its neighbours: instrument clip ← world ← patch local. That is the same value the pre-`21a570cc` code built from `patch.trafo`, which is `flattenStack (Local2Global :: modelTrafoStack)` and folds to `modelTrafo.Forward * Local2Global.Forward` for `ViewerModality.XYZ` — the modality PRo3D passes. Verified against `Aardvark.GeoSpatial.Opc` `RenderingV2.fs:337`, `TrafoSemantics.flattenStack` and `Trafo3d`'s `operator *`.

**`develop` has the same defect** — forward-ported in #740.

### 2. Numeric controls dead since the Aardvark.UI 5.7 upgrade

Cherry-pick of `561487dd`, already on `develop` and shipped in `6.1.0-prerelease003`. 6.0.0 is on Aardvark.UI 5.7.3 with the pre-5.7 resource URLs, so it is affected: Blend Factor / Min / Max / Color Map never appear in surface properties, and the controls that do render are inert. Confirmed against the installed 5.7.3 package — it ships `resources/fomantic/semantic.{js,css}` and `semantic-overrides.css`, and no `essentialstuff.js`.

### 3. The title bar reported 5.4.0

`Program.fs` carried `"5.4.0"` while the branch was 6.0.0 — this is what put a wrong version in the #733 report. Release builds were never affected (`Build.fs` rewrites that line from the release notes before publishing), but every unstamped build — `dotnet run`, the IDE, a plain `build.cmd` — reported a version three minor lines old.

The literal now says `"development build"`. Stamping is unchanged: both patch sites matched `line.StartsWith "let viewerVersion"` and rewrote the whole line, so the content never mattered to them. The two sites were byte-identical duplicates and are folded into `patchViewerVersion`, which now **fails the build** when no such line is found rather than silently publishing the placeholder — the same silent-no-op class of bug as `aebb73ae`.

### Testing

- 220 passed, 0 failed (`runTests.sh` on this branch).
- A fixture scene for the footprint is in `PRo3D.Resources.TestData` under `cases/viewplan-footprint` (generator on the develop-side PR): open it in a plain 6.0.0 build for no outline, in this branch for a red one.
- The rendering itself has not been visually confirmed in CI — that is what the fixture scene is for.

### Not in this PR

- No `6.0.1` release-notes entry, so the deploy workflow is not triggered.
- The `aebb73ae` deploy version guard is on `develop` but **not** on `releases/6.0.0` — worth backporting before 6.0.1 is cut, or that run can silently no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
